### PR TITLE
iroh-ble-transport: make construct fail cleanly instead of relying on cancellation

### DIFF
--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -368,6 +368,13 @@ async fn construct_step<T>(
 /// advertising and scanning with no owner — `Driver::stop_scan` and
 /// `stop_advertising` are reachable only through the registry actor, and on the
 /// error paths that actor never gets spawned.
+///
+/// Each flag is armed *before* its step runs, not after it succeeds: a step
+/// that trips `CONSTRUCT_STEP_TIMEOUT` has its future dropped mid-call, and the
+/// platform may well have started advertising or scanning before the call it
+/// was waiting on came back. Rolling back something that never started costs a
+/// warning; not rolling back something that did is the leak this exists to
+/// prevent.
 #[derive(Default)]
 struct ConstructRollback {
     advertising: bool,
@@ -458,6 +465,7 @@ impl BleTransport {
             local_name: "iroh".to_string(),
             service_uuids: vec![key_uuid],
         };
+        rollback.advertising = true;
         construct_step("start_advertising", async {
             peripheral
                 .start_advertising(&advertising_config)
@@ -465,9 +473,9 @@ impl BleTransport {
                 .map_err(BleError::from)
         })
         .await?;
-        rollback.advertising = true;
         info!(key_uuid = %key_uuid, "advertising started");
 
+        rollback.scanning = true;
         let scanning = construct_step("start_scan", async {
             match central
                 .start_scan(blew::central::ScanFilter::default())
@@ -480,9 +488,9 @@ impl BleTransport {
         })
         .await?;
         if scanning {
-            rollback.scanning = true;
             info!("scanning for iroh-ble peers");
         } else {
+            rollback.scanning = false;
             warn!("central start_scan not supported; discovery disabled");
         }
 

--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -138,6 +138,15 @@ impl BleTransportBuilder {
     ///
     /// Propagates errors from bringing up the BLE radio (adapter not
     /// powered, GATT registration, advertising start).
+    ///
+    /// # Cancellation
+    ///
+    /// This future is **not** cancel-safe and must not be wrapped in a
+    /// `tokio::time::timeout`. Dropping it part-way can leave the adapter
+    /// advertising and scanning with no owner, because the registry actor that
+    /// holds the only teardown path is spawned last. Every step that can hang
+    /// is already bounded internally by `CONSTRUCT_STEP_TIMEOUT`, so a wedged
+    /// Bluetooth stack surfaces as `BleError::Timeout { stage }` instead.
     pub async fn build(self, endpoint_id: EndpointId) -> BleResult<Arc<BleTransport>> {
         let central = match self.central {
             Some(c) => c,
@@ -337,6 +346,53 @@ fn adapter_wait_error(err: BlewError) -> BleError {
     }
 }
 
+/// Per-step deadline for the adapter-touching parts of [`BleTransport::construct`].
+/// Each of these calls into the platform stack and can hang there indefinitely
+/// when that stack is wedged. They are bounded here rather than by the caller
+/// because `construct` cannot be rescued from outside: cancelling it drops the
+/// future mid-way, and everything it has already started is only reachable for
+/// teardown through the registry actor, which is spawned last.
+const CONSTRUCT_STEP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+async fn construct_step<T>(
+    stage: &'static str,
+    fut: impl std::future::Future<Output = BleResult<T>>,
+) -> BleResult<T> {
+    tokio::time::timeout(CONSTRUCT_STEP_TIMEOUT, fut)
+        .await
+        .unwrap_or(Err(BleError::Timeout { stage }))
+}
+
+/// What `construct` has switched on so far, so that a failure part-way through
+/// can switch it back off. Without this a failed `construct` leaves the adapter
+/// advertising and scanning with no owner — `Driver::stop_scan` and
+/// `stop_advertising` are reachable only through the registry actor, and on the
+/// error paths that actor never gets spawned.
+#[derive(Default)]
+struct ConstructRollback {
+    advertising: bool,
+    scanning: bool,
+    l2cap_accept: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ConstructRollback {
+    async fn run(self, central: &Central, peripheral: &Peripheral) {
+        if let Some(task) = self.l2cap_accept {
+            task.abort();
+        }
+        if self.scanning
+            && let Err(e) = central.stop_scan().await
+        {
+            warn!(error = %e, "construct rollback: stop_scan failed");
+        }
+        if self.advertising
+            && let Err(e) = peripheral.stop_advertising().await
+        {
+            warn!(error = %e, "construct rollback: stop_advertising failed");
+        }
+    }
+}
+
 impl BleTransport {
     /// Start configuring a new transport. See [`BleTransportBuilder`].
     #[must_use]
@@ -351,6 +407,37 @@ impl BleTransport {
         store: Arc<dyn PeerStore>,
         l2cap_policy: L2capPolicy,
     ) -> BleResult<Arc<Self>> {
+        let central_for_rollback = Arc::clone(&central);
+        let peripheral_for_rollback = Arc::clone(&peripheral);
+        let mut rollback = ConstructRollback::default();
+        match Self::construct_inner(
+            local_id,
+            central,
+            peripheral,
+            store,
+            l2cap_policy,
+            &mut rollback,
+        )
+        .await
+        {
+            Ok(transport) => Ok(transport),
+            Err(e) => {
+                rollback
+                    .run(&central_for_rollback, &peripheral_for_rollback)
+                    .await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn construct_inner(
+        local_id: EndpointId,
+        central: Arc<Central>,
+        peripheral: Arc<Peripheral>,
+        store: Arc<dyn PeerStore>,
+        l2cap_policy: L2capPolicy,
+        rollback: &mut ConstructRollback,
+    ) -> BleResult<Arc<Self>> {
         central
             .wait_ready(std::time::Duration::from_secs(5))
             .await
@@ -362,23 +449,41 @@ impl BleTransport {
 
         let key_uuid = iroh_key_uuid(&local_id);
         let services = build_gatt_services(key_uuid);
-        register_gatt_services(&peripheral, &services).await?;
+        construct_step(
+            "register_gatt_services",
+            register_gatt_services(&peripheral, &services),
+        )
+        .await?;
         let advertising_config = AdvertisingConfig {
             local_name: "iroh".to_string(),
             service_uuids: vec![key_uuid],
         };
-        peripheral.start_advertising(&advertising_config).await?;
+        construct_step("start_advertising", async {
+            peripheral
+                .start_advertising(&advertising_config)
+                .await
+                .map_err(BleError::from)
+        })
+        .await?;
+        rollback.advertising = true;
         info!(key_uuid = %key_uuid, "advertising started");
 
-        match central
-            .start_scan(blew::central::ScanFilter::default())
-            .await
-        {
-            Ok(()) => info!("scanning for iroh-ble peers"),
-            Err(BlewError::NotSupported) => {
-                warn!("central start_scan not supported; discovery disabled");
+        let scanning = construct_step("start_scan", async {
+            match central
+                .start_scan(blew::central::ScanFilter::default())
+                .await
+            {
+                Ok(()) => Ok(true),
+                Err(BlewError::NotSupported) => Ok(false),
+                Err(e) => Err(BleError::from(e)),
             }
-            Err(e) => return Err(e.into()),
+        })
+        .await?;
+        if scanning {
+            rollback.scanning = true;
+            info!("scanning for iroh-ble peers");
+        } else {
+            warn!("central start_scan not supported; discovery disabled");
         }
 
         let (inbox_tx, inbox_rx) = mpsc::channel::<PeerCommand>(256);
@@ -414,12 +519,17 @@ impl BleTransport {
         );
 
         if l2cap_policy == L2capPolicy::PreferL2cap {
-            match peripheral.l2cap_listener().await {
+            match construct_step("l2cap_listener", async {
+                peripheral.l2cap_listener().await.map_err(BleError::from)
+            })
+            .await
+            {
                 Ok((assigned_psm, listener)) => {
                     let val = assigned_psm.value();
                     info!(psm = val, "L2CAP listener started");
                     psm_atomic.store(val, Ordering::Relaxed);
-                    tokio::spawn(run_l2cap_accept(listener, inbox_tx.clone()));
+                    rollback.l2cap_accept =
+                        Some(tokio::spawn(run_l2cap_accept(listener, inbox_tx.clone())));
                 }
                 Err(e) => {
                     warn!(error = %e, "L2CAP listener failed, falling back to GATT-only");

--- a/demos/iroh-ble-chat/src-tauri/src/lib.rs
+++ b/demos/iroh-ble-chat/src-tauri/src/lib.rs
@@ -29,11 +29,10 @@ mod key_utils;
 #[cfg(target_os = "ios")]
 mod webview_helper;
 
-/// Backstop deadline for each adapter-touching init step. `Central::with_config`
-/// / `Peripheral::new` can block indefinitely when the adapter is powered off,
-/// so without this `start_node` hangs and the UI never sees an error. Kept well
-/// above `BleTransport::build`'s own budget (5 s `wait_ready` on the central plus
-/// 5 s on the peripheral) so that its more specific error wins the race.
+/// Backstop deadline for the two blew constructors, which can block
+/// indefinitely when the adapter is powered off; without this `start_node`
+/// hangs and the UI never sees an error. `BleTransport::build` is deliberately
+/// *not* wrapped — it bounds its own steps internally and is not cancel-safe.
 const BLE_INIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// Map a blew/transport error string onto a message worth showing a tester.
@@ -46,6 +45,8 @@ fn ble_init_error_message(msg: &str) -> String {
         || msg.contains("adapter is off")
     {
         BLUETOOTH_OFF_MESSAGE.to_string()
+    } else if msg.contains("timed out at stage") {
+        BLE_STACK_STUCK_MESSAGE.to_string()
     } else {
         msg.to_string()
     }
@@ -61,15 +62,14 @@ const BLUETOOTH_UNAVAILABLE_MESSAGE: &str =
     "Bluetooth is unavailable. Check that this app is allowed to use Bluetooth in \
      Settings — simulators and emulators have no Bluetooth adapter.";
 
-/// `BleTransport::build` runs its own 5 s `wait_ready` on both roles and reports
-/// a powered-off adapter as `AdapterOff`, so an outer timeout means a later step
-/// (advertising, scan, or the L2CAP listener) wedged with the adapter powered on.
+/// `BleTransport::build` reports a powered-off adapter as `AdapterOff` from its
+/// own `wait_ready`, so its `Timeout { stage }` means a later step (advertising,
+/// scan, or the L2CAP listener) wedged with the adapter powered on.
 const BLE_STACK_STUCK_MESSAGE: &str =
     "Bluetooth did not finish starting up. Toggle Bluetooth off and on, then restart the app.";
 
-/// Run one adapter-touching init step under `BLE_INIT_TIMEOUT`. `on_timeout` is
-/// per step: what a hang implies differs between the blew constructors (the
-/// stack is down) and `BleTransport::build` (which diagnoses a down stack itself).
+/// Run one blew constructor under `BLE_INIT_TIMEOUT`. Cancelling these is safe:
+/// neither has started anything that needs tearing down by the time it returns.
 async fn ble_init_step<T>(
     what: &str,
     on_timeout: &str,
@@ -316,16 +316,19 @@ async fn start_node(
         let peripheral = Arc::new(
             ble_init_step("Peripheral::new", BLUETOOTH_OFF_MESSAGE, Peripheral::new()).await?,
         );
-        ble_init_step(
-            "BleTransport::build",
-            BLE_STACK_STUCK_MESSAGE,
-            BleTransport::builder()
-                .l2cap_policy(L2capPolicy::PreferL2cap)
-                .central(central)
-                .peripheral(peripheral)
-                .build(st.secret_key.public()),
-        )
-        .await?
+        // Not wrapped in a timeout: `build` is not cancel-safe, and dropping it
+        // part-way leaves the adapter advertising and scanning with no owner. It
+        // bounds each of its own steps instead, so it always returns on its own.
+        BleTransport::builder()
+            .l2cap_policy(L2capPolicy::PreferL2cap)
+            .central(central)
+            .peripheral(peripheral)
+            .build(st.secret_key.public())
+            .await
+            .map_err(|e| {
+                tracing::warn!("BleTransport::build failed: {e}");
+                ble_init_error_message(&e.to_string())
+            })?
     };
 
     // BLE-tuned QUIC idle timeout. The default (30s) is too lax because


### PR DESCRIPTION
## The problem

`BleTransport::construct` mutates the OS Bluetooth stack in stages and only acquires the ability to undo any of it at the very end:

| Step | Side effect |
|---|---|
| `wait_ready` ×2 | none |
| `register_gatt_services` | GATT server registered |
| `start_advertising` | **advertising live** |
| `start_scan` | **scanning live** |
| `l2cap_listener()` | **PSM bound** |
| `tokio::spawn(run_l2cap_accept)` | detached task owns the listener |
| `tokio::spawn(registry.run(…))` | the actor that can tear all of this down |

The chat app wrapped the whole thing in `tokio::time::timeout`, which does not *signal* the future — it **drops** it. Cancel anywhere between GATT registration and the registry spawn and the adapter is left advertising and scanning with nothing owning it:

- No `BleTransport` value was ever produced, so there is nothing to `Drop` — and the type has no `Drop` impl or `shutdown` method anyway.
- The only `stop_scan` / `stop_advertising` calls in the crate live in `driver.rs` and are reachable *only* through the registry actor, which on this path never gets spawned.
- The detached `run_l2cap_accept` task survives the cancellation. It only notices its inbox is gone *after* a successful accept, so with no peer connecting it parks on `listener.next()` indefinitely, holding the listener and its PSM binding for the life of the process.

A retry of `start_node` then builds a second `Central`/`Peripheral` on top of that state.

## The fix

Rather than making `construct` cancel-safe with scope guards — async `Drop` can't await, so that just trades one leak for another — this stops cancelling it, and makes it responsible for returning on its own.

**`iroh-ble-transport`**

- `CONSTRUCT_STEP_TIMEOUT` (5 s) bounds every adapter-touching step, so a wedged stack surfaces as `BleError::Timeout { stage }` instead of hanging.
- `ConstructRollback` records what has been switched on and switches it back off on every error path, including `abort()` on the L2CAP accept task.
- `construct` splits into a wrapper that owns the rollback and a `construct_inner` that does the work, so `?` early-returns can't skip cleanup.
- `BleTransportBuilder::build` documents that the future is not cancel-safe.

**`iroh-ble-chat`**

- `build` is awaited directly; the outer timeout around it is gone.
- `ble_init_step` still wraps `Central::with_config` and `Peripheral::new`, which have started nothing by the time they return and so are safe to cancel.
- `BleError::Timeout { stage }` maps onto the existing "did not finish starting up" message, so a wedged stack reads the same to a tester as before.

## Testing

`mise run verify` passes — fmt, clippy `-D warnings`, 335/335 tests, `cargo deny`, frontend typecheck — and `cargo +1.95.0 check --workspace --all-targets --all-features` confirms the 1.95 MSRV.

**No new test covers the rollback path.** `construct` takes concrete blew `Central`/`Peripheral`, and the crate has no test double for them — `blew::testing` gives `MockLink` / `MockL2capPolicy` / `MockErrorKind` for L2CAP framing (`tests/l2cap_mock.rs`), which sits below this. Covering rollback would mean new fake-adapter surface in blew. Flagging rather than implying coverage that isn't there.

## Not included

`BleTransport` still has no `shutdown()` — a successfully built transport can't be stopped without dropping the process. Worth adding, but it's a separate change from the cancellation hazard.
