### PR TITLE
iroh-ble-transport: resume after a local teardown, resurrect Dead on advertisement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,16 +174,34 @@ Key constants (registry.rs):
 
 ```
 Unknown → Discovered → Connecting → Handshaking → Connected
+             ▲                                        │
+             │                                        ▼
+             └────────────────────────────────── Draining ──→ Dead
+                                                      │          │
+                                                      ▼          ▼
+                                                Reconnecting  Discovered
+                                                      │       (on advertisement)
+                                                      ▼
+                                                  Connecting
                                                       │
                                                       ▼
-                                                   Draining ──→ Dead
-                                                      │
-                                                      ▼
-                                                Reconnecting ──→ Connecting
-                                                                    │
-                                                                    ▼
-                                                                 Restoring
+                                                   Restoring
 ```
+
+Two edges keep a present peer out of the `Dead` tombstone:
+
+- **`Draining → Discovered`** when the teardown was our own decision. The
+  `ConnectionClosed` hook raises `PeerCommand::Stalled { cause: LocalClose }`, which
+  sets `PeerEntry::resume_after_drain`; the drain then resolves back to `Discovered`
+  instead of `Dead`. It resolves on the peer's disconnect callback (~2 s) with the
+  `DRAINING_TIMEOUT` tick as a backstop for the peripheral role, and sends arriving
+  during the window are buffered rather than rejected. A `LinkDead` stall (a wedged
+  pipe, a dedup loser) still tombstones as before.
+- **`Dead → Discovered`** when the peer advertises again. An advertisement is direct
+  evidence the peer is present, so it outranks a `MaxRetries` or `Drained` tombstone
+  rather than waiting out `DEAD_GC_TTL`. `ProtocolMismatch` and `Forgotten`
+  tombstones are not resurrected — the first is a property of the peer's build, the
+  second an explicit application decision.
 
 Key constants (registry.rs):
 
@@ -194,7 +212,7 @@ Key constants (registry.rs):
 | `RESTORING_TIMEOUT` | 120 s | Max time after adapter-restore before giving up |
 | `DEAD_GC_TTL` | 60 s | How long a `Dead` entry sticks around for dedup |
 
-The transport itself is **passive**: once a peer ends up in `Dead`, the registry will not auto-retry. Reconnect policy lives in the application (see chat-app `reconnect_tick`).
+The transport itself is **passive**: it never dials on its own. Both resume edges above land in `Discovered`, which only dials when a datagram is already queued for that peer — reconnect policy stays in the application (see chat-app `reconnect_tick`).
 
 ### Routing table (`TransportRouting`)
 

--- a/crates/iroh-ble-transport/src/transport/peer.rs
+++ b/crates/iroh-ble-transport/src/transport/peer.rs
@@ -112,6 +112,11 @@ pub struct PeerEntry {
     pub verified_at: Option<Instant>,
     pub l2cap_upgrade_failed: bool,
     pub verified_live_suppressed_logged: bool,
+    /// This drain was our own decision, so rebuild the peer on demand when it
+    /// finishes instead of tombstoning it. Scoped to a single teardown: every
+    /// entry into `Draining` clears it, only a `StallCause::LocalClose` sets
+    /// it, and resolving the drain consumes it.
+    pub resume_after_drain: bool,
 }
 
 impl PeerEntry {
@@ -136,6 +141,7 @@ impl PeerEntry {
             verified_at: None,
             l2cap_upgrade_failed: false,
             verified_live_suppressed_logged: false,
+            resume_after_drain: false,
         }
     }
 }
@@ -151,6 +157,18 @@ pub struct PendingSend {
 pub enum ConnectPath {
     L2cap,
     Gatt,
+}
+
+/// Why a `PeerCommand::Stalled` was raised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StallCause {
+    /// The pipe stopped making progress, or a duplicate connection lost the
+    /// dedup race. The peer is presumed gone until it advertises again.
+    LinkDead,
+    /// We tore the pipe down ourselves — the last watched iroh connection
+    /// closed. Says nothing about the radio, so the entry is rebuilt on
+    /// demand rather than tombstoned.
+    LocalClose,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -184,7 +202,15 @@ impl From<DisconnectCause> for DisconnectReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeadReason {
     MaxRetries,
-    ProtocolMismatch { got: u8, want: u8 },
+    /// A drain or adapter-restore window expired without the entry coming
+    /// back. Distinct from `Forgotten`, which is an explicit application
+    /// decision: a `Drained` tombstone may be resurrected by a fresh
+    /// advertisement, a `Forgotten` one may not.
+    Drained,
+    ProtocolMismatch {
+        got: u8,
+        want: u8,
+    },
     Forgotten,
 }
 
@@ -299,8 +325,12 @@ pub enum PeerCommand {
         got: u8,
         want: u8,
     },
+    /// A live pipe is going away. `cause` says whether the radio stopped
+    /// answering (`LinkDead`) or we hung up on purpose (`LocalClose`); only
+    /// the former is evidence the peer is gone.
     Stalled {
         device_id: DeviceId,
+        cause: StallCause,
     },
     /// Tell the registry to evict this DeviceId entirely. Used when the
     /// routing layer detects that a known prefix has flipped to a new

--- a/crates/iroh-ble-transport/src/transport/pipe.rs
+++ b/crates/iroh-ble-transport/src/transport/pipe.rs
@@ -642,6 +642,7 @@ async fn run_gatt_pipe(
         let _ = registry_tx
             .send(PeerCommand::Stalled {
                 device_id: device_id.clone(),
+                cause: crate::transport::peer::StallCause::LinkDead,
             })
             .await;
     }
@@ -741,6 +742,7 @@ async fn run_l2cap_pipe(
         let _ = registry_tx
             .send(PeerCommand::Stalled {
                 device_id: device_id.clone(),
+                cause: crate::transport::peer::StallCause::LinkDead,
             })
             .await;
     }

--- a/crates/iroh-ble-transport/src/transport/registry.rs
+++ b/crates/iroh-ble-transport/src/transport/registry.rs
@@ -125,8 +125,8 @@ impl Registry {
             PeerCommand::Forget { device_id } => {
                 self.handle_forget(&mut actions, now, device_id);
             }
-            PeerCommand::Stalled { device_id } => {
-                self.handle_stalled(&mut actions, now, device_id);
+            PeerCommand::Stalled { device_id, cause } => {
+                self.handle_stalled(&mut actions, now, device_id, cause);
             }
             PeerCommand::Shutdown => self.handle_shutdown(&mut actions),
             PeerCommand::DataPipeReady {
@@ -423,14 +423,23 @@ impl Registry {
         let _ = rssi;
         let device_id = device.id.clone();
 
-        let has_verified_live = self.peers.values().any(|e| {
-            e.verified_endpoint
-                .map(|eid| crate::transport::routing::prefix_from_endpoint(&eid) == prefix)
-                .unwrap_or(false)
-                && matches!(e.phase, PeerPhase::Connected { .. })
-        });
+        let mut has_verified_live = false;
+        let mut verified_before = false;
+        for e in self.peers.values() {
+            if e.verified_endpoint
+                .is_some_and(|eid| crate::transport::routing::prefix_from_endpoint(&eid) == prefix)
+            {
+                verified_before = true;
+                if matches!(e.phase, PeerPhase::Connected { .. }) {
+                    has_verified_live = true;
+                }
+            }
+        }
         let i_am_lower = self.my_prefix < prefix;
-        let already_verified_peer = self.verified_prefixes.contains_key(&prefix);
+        // An entry that still remembers a completed handshake is itself proof
+        // we've verified this prefix, even when the tick pruned
+        // `verified_prefixes` because the entry had gone `Dead`.
+        let already_verified_peer = verified_before || self.verified_prefixes.contains_key(&prefix);
         let should_defer = i_am_lower && !already_verified_peer;
 
         if has_verified_live {
@@ -455,46 +464,33 @@ impl Registry {
         entry.last_adv = Some(now);
         entry.prefix = Some(prefix);
         entry.verified_live_suppressed_logged = false;
+        let defer_prefix = should_defer.then_some(prefix);
+        let mut resurrected_endpoint = None;
         match &entry.phase {
             PeerPhase::Unknown => {
-                if entry.pending_sends.is_empty() {
-                    entry.phase = PeerPhase::Discovered { since: now };
-                } else if should_defer {
-                    entry.phase = PeerPhase::PendingDial {
-                        since: now,
-                        deadline: pending_dial_deadline(now, prefix),
-                        prefix,
-                    };
-                } else {
-                    entry.phase = PeerPhase::Connecting {
-                        attempt: 0,
-                        started: now,
-                        path: crate::transport::peer::ConnectPath::Gatt,
-                    };
-                    actions.push(PeerAction::StartConnect {
-                        device_id: device_id.clone(),
-                        attempt: 0,
-                    });
-                }
+                Self::arm_for_dial(actions, entry, now, defer_prefix);
             }
             PeerPhase::Discovered { .. } if !entry.pending_sends.is_empty() => {
-                if should_defer {
-                    entry.phase = PeerPhase::PendingDial {
-                        since: now,
-                        deadline: pending_dial_deadline(now, prefix),
-                        prefix,
-                    };
-                } else {
-                    entry.phase = PeerPhase::Connecting {
-                        attempt: 0,
-                        started: now,
-                        path: crate::transport::peer::ConnectPath::Gatt,
-                    };
-                    actions.push(PeerAction::StartConnect {
-                        device_id: device_id.clone(),
-                        attempt: 0,
-                    });
-                }
+                Self::arm_for_dial(actions, entry, now, defer_prefix);
+            }
+            // `Dead` means we had reason to believe this peer was gone. An
+            // advertisement received now is direct evidence to the contrary,
+            // and it outranks the reason we tombstoned it — otherwise a peer
+            // sitting a foot away is ignored until DEAD_GC_TTL expires.
+            //
+            // Not every tombstone: `ProtocolMismatch` is a determinate
+            // property of the peer's build, so redialing it buys a connect
+            // plus a version read per advertisement, and `Forgotten` is an
+            // explicit application decision we have no business overriding.
+            PeerPhase::Dead {
+                reason:
+                    crate::transport::peer::DeadReason::MaxRetries
+                    | crate::transport::peer::DeadReason::Drained,
+                ..
+            } => {
+                Self::clear_connection_state(entry);
+                resurrected_endpoint = entry.verified_endpoint;
+                Self::arm_for_dial(actions, entry, now, defer_prefix);
             }
             PeerPhase::Reconnecting {
                 attempt, next_at, ..
@@ -511,6 +507,15 @@ impl Registry {
                 });
             }
             _ => {}
+        }
+        // The peer's identity was proven once and that hasn't expired with
+        // the tombstone, so restore the entry in `verified_prefixes` (pruned
+        // by the tick while it was `Dead`). Without this a peer we just had
+        // verified is treated as a stranger and takes the fairness defer.
+        if let Some(endpoint) = resurrected_endpoint
+            && crate::transport::routing::prefix_from_endpoint(&endpoint) == prefix
+        {
+            self.verified_prefixes.insert(prefix, endpoint);
         }
     }
 
@@ -538,6 +543,7 @@ impl Registry {
         }
         let entry_phase_kind = PhaseKind::from(&entry.phase);
         let entry_tx_gen = entry.tx_gen;
+        let resume_after_drain = entry.resume_after_drain;
         let decision = match &entry.phase {
             PeerPhase::Connected {
                 tx_gen: live_gen, ..
@@ -555,6 +561,11 @@ impl Registry {
             | PeerPhase::Handshaking { .. }
             | PeerPhase::Reconnecting { .. }
             | PeerPhase::Restoring { .. } => SendDecision::Buffer,
+            // A drain we asked for ends in a live entry again, so hold the
+            // datagram instead of failing it — otherwise reconnect latency
+            // depends on where the application's redial lands relative to
+            // the drain window.
+            PeerPhase::Draining { .. } if resume_after_drain => SendDecision::Buffer,
             PeerPhase::Draining { .. } | PeerPhase::Dead { .. } => SendDecision::Reject,
         };
         let decision_tag = match &decision {
@@ -1028,6 +1039,15 @@ impl Registry {
             return;
         };
         let reason = crate::transport::peer::DisconnectReason::from(cause);
+        if entry.resume_after_drain && matches!(entry.phase, PeerPhase::Draining { .. }) {
+            // The disconnect callback is the signal our own CloseChannel
+            // actually landed, so the drain is done — resolving here instead
+            // of idling out DRAINING_TIMEOUT is the difference between a ~2 s
+            // and a 5 s reconnect floor. Re-draining would be worse than a
+            // no-op: it resets `since` and extends the window.
+            Self::resume_drained_entry(actions, entry, now);
+            return;
+        }
         // A DeviceDisconnected for a peer we were in the middle of
         // dialing IS the connect failure — there is no live pipe to
         // drain. Historically this arm raced with `ConnectFailed`
@@ -1197,22 +1217,28 @@ impl Registry {
                     });
                 }
                 TickAction::DrainingToDead => {
-                    // After the drain window, stop trying to rescue
-                    // this DeviceId. Reconnection is driven by fresh
-                    // advertising creating a new entry (common case:
-                    // Android MAC randomization on peer restart) or by
-                    // iroh issuing a new SendDatagram, not by the
-                    // registry's own retry loop.
-                    entry.target_endpoint = None;
-                    entry.phase = PeerPhase::Dead {
-                        reason: crate::transport::peer::DeadReason::Forgotten,
-                        at: tick_now,
-                    };
+                    if entry.resume_after_drain {
+                        // Backstop for the peripheral role, where no
+                        // disconnect callback arrives to resolve the drain.
+                        Self::resume_drained_entry(actions, entry, tick_now);
+                    } else {
+                        // After the drain window, stop trying to rescue
+                        // this DeviceId. Reconnection is driven by fresh
+                        // advertising creating a new entry (common case:
+                        // Android MAC randomization on peer restart) or by
+                        // iroh issuing a new SendDatagram, not by the
+                        // registry's own retry loop.
+                        entry.target_endpoint = None;
+                        entry.phase = PeerPhase::Dead {
+                            reason: crate::transport::peer::DeadReason::Drained,
+                            at: tick_now,
+                        };
+                    }
                 }
                 TickAction::RestoringToDead => {
                     entry.target_endpoint = None;
                     entry.phase = PeerPhase::Dead {
-                        reason: crate::transport::peer::DeadReason::Forgotten,
+                        reason: crate::transport::peer::DeadReason::Drained,
                         at: tick_now,
                     };
                 }
@@ -1313,6 +1339,7 @@ impl Registry {
         actions: &mut Vec<PeerAction>,
         now: std::time::Instant,
         device_id: DeviceId,
+        cause: crate::transport::peer::StallCause,
     ) {
         let Some(entry) = self.peers.get_mut(&device_id) else {
             return;
@@ -1324,8 +1351,20 @@ impl Registry {
         }) else {
             return;
         };
-        let reason = crate::transport::peer::DisconnectReason::LinkDead;
+        let reason = match cause {
+            crate::transport::peer::StallCause::LinkDead => {
+                crate::transport::peer::DisconnectReason::LinkDead
+            }
+            crate::transport::peer::StallCause::LocalClose => {
+                crate::transport::peer::DisconnectReason::LocalClose
+            }
+        };
         let broken_pipe_acks = Self::drain_to_draining(entry, now, reason.clone());
+        // Hanging up is a local decision, not evidence about the radio: drain
+        // the pipe, but let the entry come back once the close has landed
+        // instead of tombstoning it for DEAD_GC_TTL. Set after the drain,
+        // which clears the flag.
+        entry.resume_after_drain = matches!(cause, crate::transport::peer::StallCause::LocalClose);
         actions.extend(broken_pipe_acks);
         actions.push(PeerAction::CloseChannel {
             device_id: device_id.clone(),
@@ -1707,6 +1746,61 @@ impl Registry {
         self.peers.iter()
     }
 
+    /// Wipe the leftovers of a connection that is definitively gone, so the
+    /// entry can be reused for a fresh one.
+    fn clear_connection_state(entry: &mut PeerEntry) {
+        entry.consecutive_failures = 0;
+        entry.pipe = None;
+        entry.l2cap_channel = None;
+        entry.l2cap_upgrade_failed = false;
+        entry.subscribed_chars.clear();
+        entry.rx_backlog.clear();
+        entry.resume_after_drain = false;
+        entry.verified_live_suppressed_logged = false;
+    }
+
+    /// Park an entry that is ready to be dialled again: idle in `Discovered`
+    /// unless datagrams are already queued, in which case dial — or, when
+    /// `defer_prefix` is set, let the peer dial us first under the fairness
+    /// rule.
+    fn arm_for_dial(
+        actions: &mut Vec<PeerAction>,
+        entry: &mut PeerEntry,
+        now: std::time::Instant,
+        defer_prefix: Option<crate::transport::peer::KeyPrefix>,
+    ) {
+        if entry.pending_sends.is_empty() {
+            entry.phase = PeerPhase::Discovered { since: now };
+        } else if let Some(prefix) = defer_prefix {
+            entry.phase = PeerPhase::PendingDial {
+                since: now,
+                deadline: pending_dial_deadline(now, prefix),
+                prefix,
+            };
+        } else {
+            entry.phase = PeerPhase::Connecting {
+                attempt: 0,
+                started: now,
+                path: crate::transport::peer::ConnectPath::Gatt,
+            };
+            actions.push(PeerAction::StartConnect {
+                device_id: entry.device_id.clone(),
+                attempt: 0,
+            });
+        }
+    }
+
+    /// Finish a drain we asked for ourselves. The peer was never presumed
+    /// gone, so it goes back to being dialable instead of `Dead`.
+    fn resume_drained_entry(
+        actions: &mut Vec<PeerAction>,
+        entry: &mut PeerEntry,
+        now: std::time::Instant,
+    ) {
+        Self::clear_connection_state(entry);
+        Self::arm_for_dial(actions, entry, now, None);
+    }
+
     fn drain_to_draining(
         entry: &mut PeerEntry,
         now: std::time::Instant,
@@ -1715,6 +1809,10 @@ impl Registry {
         let mut out = Vec::new();
         let was_connected = matches!(entry.phase, PeerPhase::Connected { .. });
         entry.pipe = None;
+        // Every path into `Draining` lands here, so clearing the resume intent
+        // by default keeps it scoped to the one teardown that asked for it —
+        // `handle_stalled` re-arms it immediately afterwards.
+        entry.resume_after_drain = false;
         // Scope the no-retry sticky bit to the current connection: future
         // reconnects start fresh and are allowed to attempt L2CAP again.
         entry.l2cap_upgrade_failed = false;
@@ -3381,7 +3479,7 @@ mod tests {
         assert!(actions.is_empty(), "Draining->Dead does not emit actions");
         match &reg.peer(&device_id).unwrap().phase {
             PeerPhase::Dead { reason, .. } => {
-                assert_eq!(*reason, crate::transport::peer::DeadReason::Forgotten);
+                assert_eq!(*reason, crate::transport::peer::DeadReason::Drained);
             }
             other => panic!("wrong phase: {other:?}"),
         }
@@ -3401,7 +3499,7 @@ mod tests {
         assert!(matches!(
             reg.peer(&device_id).unwrap().phase,
             PeerPhase::Dead {
-                reason: crate::transport::peer::DeadReason::Forgotten,
+                reason: crate::transport::peer::DeadReason::Drained,
                 ..
             }
         ));
@@ -3453,6 +3551,7 @@ mod tests {
         });
         let actions = reg.handle(PeerCommand::Stalled {
             device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LinkDead,
         });
         assert!(
             actions
@@ -3466,6 +3565,366 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    fn connected_entry(reg: &mut Registry, device_id: &DeviceId) {
+        reg.peers.insert(device_id.clone(), {
+            let mut e = PeerEntry::new(device_id.clone());
+            e.phase = PeerPhase::Connected {
+                since: std::time::Instant::now(),
+                channel: crate::transport::peer::ChannelHandle {
+                    id: 1,
+                    path: crate::transport::peer::ConnectPath::Gatt,
+                },
+                tx_gen: 1,
+                upgrading: false,
+            };
+            e
+        });
+    }
+
+    fn advertise(reg: &mut Registry, device_id: &DeviceId, prefix: [u8; 12]) -> Vec<PeerAction> {
+        reg.handle(PeerCommand::Advertised {
+            prefix,
+            device: blew::BleDevice {
+                id: device_id.clone(),
+                name: None,
+                rssi: None,
+                services: vec![],
+            },
+            rssi: None,
+        })
+    }
+
+    fn dead_entry(
+        reg: &mut Registry,
+        device_id: &DeviceId,
+        reason: crate::transport::peer::DeadReason,
+    ) {
+        reg.peers.insert(device_id.clone(), {
+            let mut e = PeerEntry::new(device_id.clone());
+            e.phase = PeerPhase::Dead {
+                reason,
+                at: std::time::Instant::now(),
+            };
+            e
+        });
+    }
+
+    fn queue_send(reg: &mut Registry, device_id: &DeviceId) {
+        reg.peers
+            .get_mut(device_id)
+            .unwrap()
+            .pending_sends
+            .push_back(crate::transport::peer::PendingSend {
+                tx_gen: 0,
+                datagram: bytes::Bytes::from_static(b"hi"),
+                waker: noop_waker(),
+            });
+    }
+
+    #[test]
+    fn stalled_local_close_drains_and_marks_entry_for_resume() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-local-close");
+        connected_entry(&mut reg, &device_id);
+
+        let actions = reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LocalClose,
+        });
+
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, PeerAction::CloseChannel { .. })),
+            "the BLE channel is still closed on a local teardown"
+        );
+        let entry = reg.peer(&device_id).unwrap();
+        assert!(matches!(
+            entry.phase,
+            PeerPhase::Draining {
+                reason: crate::transport::peer::DisconnectReason::LocalClose,
+                ..
+            }
+        ));
+        assert!(entry.resume_after_drain);
+    }
+
+    #[test]
+    fn resumable_drain_returns_to_discovered_instead_of_dead() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resume-tick");
+        connected_entry(&mut reg, &device_id);
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LocalClose,
+        });
+
+        let past_drain = std::time::Instant::now() + DRAINING_TIMEOUT + Duration::from_secs(1);
+        reg.handle(PeerCommand::Tick(past_drain));
+
+        let entry = reg.peer(&device_id).unwrap();
+        assert!(
+            matches!(entry.phase, PeerPhase::Discovered { .. }),
+            "expected Discovered, got {:?}",
+            entry.phase
+        );
+        assert!(!entry.resume_after_drain, "resume intent is consumed once");
+    }
+
+    #[test]
+    fn link_dead_drain_still_tombstones() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-link-dead-tick");
+        connected_entry(&mut reg, &device_id);
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LinkDead,
+        });
+
+        let past_drain = std::time::Instant::now() + DRAINING_TIMEOUT + Duration::from_secs(1);
+        reg.handle(PeerCommand::Tick(past_drain));
+
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Dead {
+                reason: crate::transport::peer::DeadReason::Drained,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn central_disconnected_resolves_resumable_drain_immediately() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resume-callback");
+        connected_entry(&mut reg, &device_id);
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LocalClose,
+        });
+
+        // No tick: the disconnect callback alone resolves the drain, which is
+        // what keeps the reconnect floor at the callback latency (~2 s on
+        // hardware) rather than DRAINING_TIMEOUT.
+        reg.handle(PeerCommand::CentralDisconnected {
+            device_id: device_id.clone(),
+            cause: blew::DisconnectCause::LocalClose,
+        });
+
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Discovered { .. }
+        ));
+    }
+
+    #[test]
+    fn send_during_resumable_drain_buffers_then_dials() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resume-send");
+        connected_entry(&mut reg, &device_id);
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LocalClose,
+        });
+
+        let actions = reg.handle(PeerCommand::SendDatagram {
+            device_id: device_id.clone(),
+            target_endpoint: None,
+            tx_gen: 2,
+            datagram: bytes::Bytes::from_static(b"redial"),
+            waker: noop_waker(),
+        });
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, PeerAction::AckSend { result: Ok(()), .. })),
+            "a redial during our own teardown is accepted, not failed"
+        );
+        assert_eq!(reg.peer(&device_id).unwrap().pending_sends.len(), 1);
+
+        let past_drain = std::time::Instant::now() + DRAINING_TIMEOUT + Duration::from_secs(1);
+        let actions = reg.handle(PeerCommand::Tick(past_drain));
+        assert!(
+            actions.iter().any(
+                |a| matches!(a, PeerAction::StartConnect { device_id: d, .. } if *d == device_id)
+            ),
+            "the buffered datagram dials as soon as the drain resolves"
+        );
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Connecting { .. }
+        ));
+    }
+
+    #[test]
+    fn resume_intent_does_not_survive_into_the_next_teardown() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resume-scope");
+        connected_entry(&mut reg, &device_id);
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LocalClose,
+        });
+        reg.handle(PeerCommand::CentralDisconnected {
+            device_id: device_id.clone(),
+            cause: blew::DisconnectCause::LocalClose,
+        });
+
+        // Same entry reconnects, then the radio genuinely goes away. The
+        // earlier local teardown must not make this one resumable too.
+        reg.peers.get_mut(&device_id).unwrap().phase = PeerPhase::Connected {
+            since: std::time::Instant::now(),
+            channel: crate::transport::peer::ChannelHandle {
+                id: 2,
+                path: crate::transport::peer::ConnectPath::Gatt,
+            },
+            tx_gen: 2,
+            upgrading: false,
+        };
+        reg.handle(PeerCommand::Stalled {
+            device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LinkDead,
+        });
+        assert!(!reg.peer(&device_id).unwrap().resume_after_drain);
+
+        let past_drain = std::time::Instant::now() + DRAINING_TIMEOUT + Duration::from_secs(1);
+        reg.handle(PeerCommand::Tick(past_drain));
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Dead { .. }
+        ));
+    }
+
+    #[test]
+    fn advertisement_resurrects_drained_dead_entry() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resurrect");
+        dead_entry(
+            &mut reg,
+            &device_id,
+            crate::transport::peer::DeadReason::Drained,
+        );
+
+        let actions = advertise(&mut reg, &device_id, [0u8; 12]);
+
+        assert!(actions.is_empty(), "no queued sends, so no dial");
+        assert!(
+            matches!(
+                reg.peer(&device_id).unwrap().phase,
+                PeerPhase::Discovered { .. }
+            ),
+            "a live advertisement outranks the tombstone"
+        );
+    }
+
+    #[test]
+    fn advertisement_resurrects_max_retries_entry_and_dials_queued_sends() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-resurrect-dial");
+        dead_entry(
+            &mut reg,
+            &device_id,
+            crate::transport::peer::DeadReason::MaxRetries,
+        );
+        reg.peers.get_mut(&device_id).unwrap().consecutive_failures = MAX_CONNECT_ATTEMPTS;
+        queue_send(&mut reg, &device_id);
+
+        // [0u8; 12] sorts below any real pubkey prefix, so `should_defer` is
+        // false and this dials rather than waiting out the fairness window.
+        let actions = advertise(&mut reg, &device_id, [0u8; 12]);
+
+        assert!(actions.iter().any(
+            |a| matches!(a, PeerAction::StartConnect { device_id: d, .. } if *d == device_id)
+        ));
+        let entry = reg.peer(&device_id).unwrap();
+        assert!(matches!(entry.phase, PeerPhase::Connecting { .. }));
+        assert_eq!(
+            entry.consecutive_failures, 0,
+            "a resurrected peer gets a fresh retry budget"
+        );
+    }
+
+    #[test]
+    fn advertisement_does_not_resurrect_protocol_mismatch() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-mismatch");
+        dead_entry(
+            &mut reg,
+            &device_id,
+            crate::transport::peer::DeadReason::ProtocolMismatch { got: 9, want: 1 },
+        );
+
+        advertise(&mut reg, &device_id, [0u8; 12]);
+
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Dead {
+                reason: crate::transport::peer::DeadReason::ProtocolMismatch { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn advertisement_does_not_resurrect_forgotten_peer() {
+        let mut reg = Registry::new_for_test();
+        let device_id = blew::DeviceId::from("dev-forgotten");
+        dead_entry(
+            &mut reg,
+            &device_id,
+            crate::transport::peer::DeadReason::Forgotten,
+        );
+
+        advertise(&mut reg, &device_id, [0u8; 12]);
+
+        assert!(matches!(
+            reg.peer(&device_id).unwrap().phase,
+            PeerPhase::Dead {
+                reason: crate::transport::peer::DeadReason::Forgotten,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resurrected_entry_restores_verified_prefix() {
+        use crate::transport::routing::prefix_from_endpoint;
+
+        // We must be the lower prefix for `should_defer` to be live at all;
+        // pubkey ordering doesn't follow seed ordering, so sort them.
+        let (my_ep, peer_ep) = {
+            let a = endpoint_from_seed(0x01);
+            let b = endpoint_from_seed(0xFF);
+            if a.as_bytes() < b.as_bytes() {
+                (a, b)
+            } else {
+                (b, a)
+            }
+        };
+        let peer_prefix = prefix_from_endpoint(&peer_ep);
+
+        let mut reg = Registry::new_for_test_with_endpoint(my_ep);
+        let device_id = blew::DeviceId::from("dev-reverify");
+        dead_entry(
+            &mut reg,
+            &device_id,
+            crate::transport::peer::DeadReason::Drained,
+        );
+        reg.peers.get_mut(&device_id).unwrap().verified_endpoint = Some(peer_ep);
+        queue_send(&mut reg, &device_id);
+
+        advertise(&mut reg, &device_id, peer_prefix);
+
+        assert_eq!(reg.verified_prefixes.get(&peer_prefix), Some(&peer_ep));
+        assert!(
+            matches!(
+                reg.peer(&device_id).unwrap().phase,
+                PeerPhase::Connecting { .. }
+            ),
+            "a peer we already verified should not take the fairness defer again"
+        );
     }
 
     fn tick_wedged_pipe_test_body(path: crate::transport::peer::ConnectPath) {
@@ -3611,6 +4070,7 @@ mod tests {
         });
         let actions = reg.handle(PeerCommand::Stalled {
             device_id: device_id.clone(),
+            cause: crate::transport::peer::StallCause::LinkDead,
         });
         assert!(actions.is_empty());
         assert!(matches!(

--- a/crates/iroh-ble-transport/src/transport/routing.rs
+++ b/crates/iroh-ble-transport/src/transport/routing.rs
@@ -1648,6 +1648,60 @@ mod tests {
         assert!(r.device_for_endpoint(&test_endpoint(81)).is_none());
     }
 
+    /// The redial seam behind #12. Resuming the registry after a local
+    /// teardown only helps if routing can still translate the endpoint back
+    /// into a `DeviceId` — otherwise the peer is dialable and nothing ever
+    /// asks it to dial. Walks the whole chain the way the real code does:
+    /// `handle_hook_event`'s `ConnectionClosed` arm evicts, the driver's
+    /// pipe-close path evicts the pipe, then `BleAddressLookup::resolve` and
+    /// `poll_send` have to find their way home.
+    #[test]
+    fn endpoint_still_resolves_to_its_device_after_a_local_teardown() {
+        let r = Routing::new();
+        let endpoint = test_endpoint(0x21);
+        let prefix = prefix_from_endpoint(&endpoint);
+        let device = dev("peer-teardown");
+
+        // Scan saw the peer, iroh dialled it, the pipe went routable.
+        r.note_scan_hint(prefix, device.clone());
+        let reserved = r.reserve_outbound(endpoint);
+        let consumed = r
+            .consume_reservation_for_prefix(&prefix)
+            .expect("driver consumes the reservation at pipe-open");
+        assert_eq!(consumed.stable_id, reserved);
+        r.register_pipe_with_id(reserved, device.clone(), Direction::Outbound);
+        r.insert_routable(endpoint, reserved, Dialer::Low);
+
+        // The teardown: what the `ConnectionClosed` arm does, plus the
+        // driver's pipe-close eviction.
+        assert!(r.evict_routable_if_pipe(&endpoint, reserved).is_some());
+        r.evict_pipe_state(reserved);
+        r.evict_pipe(reserved);
+
+        // Resolve, step by step. Every pipe-shaped source is gone...
+        assert!(r.routable_pipe_for(&endpoint).is_none());
+        assert!(r.pending_pipe_for(&endpoint).is_none());
+        assert!(r.reservation_for_prefix(&prefix).is_none());
+        // ...but the scan hint outlives the connection: no production path
+        // calls `forget_scan_hint`, which is exactly why a redial can find
+        // the peer without waiting for another advertisement.
+        assert_eq!(r.scan_hint_for_prefix(&prefix), Some(device.clone()));
+
+        let redial = r.reserve_outbound(endpoint);
+        assert_ne!(
+            redial, reserved,
+            "the redial gets a fresh id, not the dead pipe's"
+        );
+
+        // And `poll_send`'s translation of that CustomAddr back to a device.
+        assert!(r.device_for_pipe(redial).is_none());
+        let (target, target_prefix) = r
+            .reservation_target(redial)
+            .expect("the fresh reservation resolves");
+        assert_eq!(target, endpoint);
+        assert_eq!(r.scan_hint_for_prefix(&target_prefix), Some(device));
+    }
+
     #[test]
     fn forget_scan_hint_is_idempotent() {
         let r = Routing::new();

--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -30,7 +30,7 @@ use crate::transport::events::{
     run_central_events, run_l2cap_accept, run_peripheral_requests, run_peripheral_state_events,
 };
 use crate::transport::hook::{BleDedupHook, HookEvent};
-use crate::transport::peer::{ConnectPath, KEY_PREFIX_LEN, PeerCommand};
+use crate::transport::peer::{ConnectPath, KEY_PREFIX_LEN, PeerCommand, StallCause};
 use crate::transport::registry::{PhaseKind, Registry, RegistryHandle, SnapshotMaps};
 use crate::transport::routing::{
     TOKEN_LEN, local_custom_addr, parse_token_addr, token_custom_addr,
@@ -294,7 +294,12 @@ async fn handle_hook_event(
             // pipe worker then exits, which evicts the lingering routing
             // pipe record.
             for device_id in evicted_devices {
-                inbox.send(PeerCommand::Stalled { device_id }).await?;
+                inbox
+                    .send(PeerCommand::Stalled {
+                        device_id,
+                        cause: StallCause::LinkDead,
+                    })
+                    .await?;
             }
             inbox
                 .send(PeerCommand::VerifiedEndpoint { endpoint_id, token })
@@ -317,7 +322,12 @@ async fn handle_hook_event(
                         device = %device_id,
                         "all watched iroh connections closed; tearing BLE pipe down"
                     );
-                    inbox.send(PeerCommand::Stalled { device_id }).await?;
+                    inbox
+                        .send(PeerCommand::Stalled {
+                            device_id,
+                            cause: StallCause::LocalClose,
+                        })
+                        .await?;
                 }
             }
             Ok(())
@@ -1131,8 +1141,9 @@ mod tests {
         .expect("hook event should forward");
 
         match rx.try_recv().expect("Stalled emitted first") {
-            PeerCommand::Stalled { device_id } => {
+            PeerCommand::Stalled { device_id, cause } => {
                 assert_eq!(device_id, evicted);
+                assert_eq!(cause, StallCause::LinkDead);
             }
             other => panic!("expected Stalled, got {other:?}"),
         }
@@ -1169,8 +1180,9 @@ mod tests {
 
         assert_eq!(routing.routable_pipe_for(&endpoint_id), None);
         match rx.try_recv().expect("Stalled emitted") {
-            PeerCommand::Stalled { device_id } => {
+            PeerCommand::Stalled { device_id, cause } => {
                 assert_eq!(device_id, dev("close-current"));
+                assert_eq!(cause, StallCause::LocalClose);
             }
             other => panic!("expected Stalled, got {other:?}"),
         }

--- a/crates/iroh-ble-transport/tests/mock_integration.rs
+++ b/crates/iroh-ble-transport/tests/mock_integration.rs
@@ -157,6 +157,117 @@ async fn mid_session_disconnect_drains_and_closes_channel() {
     );
 }
 
+/// A teardown we asked for ourselves (the last watched iroh connection closed,
+/// so `handle_hook_event` raises `Stalled { LocalClose }`) must not tombstone
+/// the peer. Before this, the entry went `Draining` → `Dead` and sat there for
+/// `DEAD_GC_TTL`, giving a hard 65 s floor on redialing a peer a foot away.
+#[tokio::test]
+async fn local_teardown_lets_the_peer_be_redialed_immediately() {
+    let iface = Arc::new(MockBleInterface::new());
+    let device_id = blew::DeviceId::from("dev-teardown");
+    for id in [1u64, 2] {
+        iface.on_connect(
+            device_id.clone(),
+            Ok(ChannelHandle {
+                id,
+                path: ConnectPath::Gatt,
+            }),
+        );
+    }
+
+    let (tx, rx) = mpsc::channel::<PeerCommand>(256);
+    let (incoming_tx, _incoming_rx) = mpsc::channel::<IncomingPacket>(16);
+    let snapshots = Arc::new(ArcSwap::from(Arc::new(SnapshotMaps::default())));
+    let (retransmits, truncations, empty_frames) = zero_counters();
+    let routing_local = Arc::new(iroh_ble_transport::transport::routing::Routing::new());
+    let driver = Driver::new(
+        iface.clone(),
+        tx.clone(),
+        incoming_tx,
+        retransmits,
+        truncations,
+        empty_frames,
+        Arc::new(InMemoryPeerStore::new()),
+        Arc::clone(&routing_local),
+    );
+    let reg = Registry::new_for_test_with_policy(L2capPolicy::Disabled);
+    let snap_for_actor = snapshots.clone();
+    tokio::spawn(async move {
+        reg.run(
+            rx,
+            driver,
+            snap_for_actor,
+            test_wakers(),
+            Arc::clone(&routing_local),
+        )
+        .await;
+    });
+
+    let prefix: KeyPrefix = [7u8; KEY_PREFIX_LEN];
+    let advertise = || PeerCommand::Advertised {
+        prefix,
+        device: blew::BleDevice {
+            id: device_id.clone(),
+            name: None,
+            rssi: None,
+            services: vec![],
+        },
+        rssi: None,
+    };
+    let (waker_tx, _waker_rx) = mpsc::channel::<()>(4);
+    let send = |datagram: &'static [u8]| PeerCommand::SendDatagram {
+        device_id: device_id.clone(),
+        target_endpoint: None,
+        tx_gen: 0,
+        datagram: bytes::Bytes::from_static(datagram),
+        waker: waker_from_channel(waker_tx.clone()),
+    };
+
+    tx.send(advertise()).await.unwrap();
+    tx.send(send(b"ping")).await.unwrap();
+    wait_for_call_count(
+        &iface,
+        CallKindMatcher::Connect,
+        1,
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+
+    // The application hangs up: the pipe is torn down on purpose.
+    tx.send(PeerCommand::Stalled {
+        device_id: device_id.clone(),
+        cause: iroh_ble_transport::transport::peer::StallCause::LocalClose,
+    })
+    .await
+    .unwrap();
+    wait_for_call_count(
+        &iface,
+        CallKindMatcher::Disconnect,
+        1,
+        std::time::Duration::from_secs(2),
+    )
+    .await;
+    // The disconnect callback confirms the close landed, which resolves the
+    // drain without waiting out DRAINING_TIMEOUT.
+    tx.send(PeerCommand::CentralDisconnected {
+        device_id: device_id.clone(),
+        cause: blew::DisconnectCause::LocalClose,
+    })
+    .await
+    .unwrap();
+
+    // The application redials. No tick, no GC wait: the entry is dialable now.
+    tx.send(advertise()).await.unwrap();
+    tx.send(send(b"ping-again")).await.unwrap();
+    wait_for_call_count(
+        &iface,
+        CallKindMatcher::Connect,
+        2,
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn adapter_toggle_reconnects_all_peers_with_single_purge() {
     let iface = Arc::new(MockBleInterface::new());


### PR DESCRIPTION
Fixes #12.

A deliberate pipe teardown put a hard **65 s floor** on reconnecting to a peer that was advertising the whole time: `DRAINING_TIMEOUT` (5 s) + `DEAD_GC_TTL` (60 s), with `handle_advertised` having no `Dead` arm so nothing could shorten it.

Two independent changes, matching the issue's suggested fixes (1) and (2).

## A. A teardown we chose doesn't tombstone the peer

`PeerCommand::Stalled` now carries a `StallCause`. `handle_hook_event`'s `ConnectionClosed` arm raises `LocalClose`; the wedged-pipe check, the dedup eviction and the two pipe-level link-death senders keep raising `LinkDead`. A `LocalClose` stall sets `PeerEntry::resume_after_drain`, and the drain resolves back to `Discovered` rather than `Dead`.

Intent lives on `PeerEntry`, not on `PeerPhase::Draining`'s `reason`: a `CentralDisconnected` mid-drain re-enters `drain_to_draining` and overwrites the phase, and blew reports the cause as whatever the force-close path produces. `drain_to_draining` clears the flag and `handle_stalled` re-arms it, so the intent is scoped to exactly one teardown.

Two latency details fall out of it:

- The drain resolves on the peer's **disconnect callback** instead of idling out `DRAINING_TIMEOUT` — that callback is the signal our own `CloseChannel` landed (~2.0 s in the issue's log). Re-draining there was worse than a no-op: it reset `since` and *extended* the window. The tick stays as the backstop for the peripheral role, where no such callback arrives.
- Datagrams arriving **during** a resumable drain buffer instead of being rejected, so reconnect no longer depends on where the app's 10 s `reconnect_tick` lands relative to the drain.

`DRAINING_TIMEOUT` and `DEAD_GC_TTL` are unchanged. The 5 s drain is worth keeping as the backstop: the issue's log shows the GATT close landing ~2.0 s after the request, so redialing sooner risks dialing a half-closed device.

## B. An advertisement resurrects a `Dead` entry

`Dead` means "we have reason to believe this peer is gone"; an advertisement received now is direct evidence to the contrary. `handle_advertised` gains a `Dead` arm that resets the entry and re-arms it — for `MaxRetries` and the new `Drained` reason only:

- `ProtocolMismatch` stays dead — a determinate property of that peer's build, and resurrecting it buys a connect plus a version read per advertisement.
- `Forgotten` stays dead — an explicit application decision.

`DeadReason::Drained` splits the drain/restore-timeout tombstones out of `Forgotten`, which now means only an explicit `Forget`.

The issue's fix (3) mostly falls out of A — the entry never becomes `Dead`, so `prune_verified_prefixes` keeps its prefix. For B, an entry that still remembers a completed handshake now counts as verified for the fairness rule, so a resurrected peer skips the `should_defer` → `PendingDial` detour instead of being treated as a stranger, and `verified_prefixes` is repopulated for other consumers.

## Effect

Deliberate teardown → reconnect goes from **65 s** to the disconnect callback (~2 s, 5 s worst case on the peripheral side) plus the normal connect + handshake, so roughly **4–8 s** on the issue's hardware. A genuinely dead peer that starts advertising again recovers on the next advertisement rather than after `DEAD_GC_TTL`.

## Tests

`mise run verify` is green (348 tests). New coverage:

- `stalled_local_close_drains_and_marks_entry_for_resume`
- `resumable_drain_returns_to_discovered_instead_of_dead`
- `link_dead_drain_still_tombstones`
- `central_disconnected_resolves_resumable_drain_immediately`
- `send_during_resumable_drain_buffers_then_dials`
- `resume_intent_does_not_survive_into_the_next_teardown`
- `advertisement_resurrects_drained_dead_entry`, `..._max_retries_entry_and_dials_queued_sends`
- `advertisement_does_not_resurrect_protocol_mismatch`, `..._forgotten_peer`
- `resurrected_entry_restores_verified_prefix`
- `mock_integration::local_teardown_lets_the_peer_be_redialed_immediately` — end-to-end through the driver; confirmed it fails (times out waiting for the second connect) if the stall cause is flipped back to `LinkDead`.
- `routing::endpoint_still_resolves_to_its_device_after_a_local_teardown` — walks the redial seam: the hook's two evictions plus the driver's pipe eviction, then resolve's fallthrough to a fresh reservation and `poll_send`'s translation of it back to a `DeviceId`. The load-bearing fact is that `scan_hint` outlives the connection (no production path calls `forget_scan_hint`), which is what lets a deliberately torn-down peer be redialed without waiting for another advertisement. This one characterizes existing routing behaviour — it passes on `main` too — and is here as a guard, since the resume is worthless if that ever stops holding.

### What is still unverified

- The 65 s → single-digit claim is arithmetic on the issue's log plus the code path, not a measurement. Nothing here has touched a radio, and the peripheral-side 5 s backstop and iOS behaviour are unmeasured.
- The routing test is a unit test over `Routing` in isolation: it asserts the state transitions, not that iroh's resolver re-polls and picks up the new reservation through a real waker loop.
- `Dead { MaxRetries }` resurrection removes a cooldown. `MAX_CONNECT_ATTEMPTS` is checked against the phase's `attempt`, which restarts at 0 on resurrection, so a peer that advertises healthily but never completes a connect now gets a fresh 15-attempt burst on the next advertisement instead of waiting out `DEAD_GC_TTL`. The per-attempt backoff (capped at 30 s) still spaces the burst. This is what the issue asked for; flagging the other side of it.

## Not fixed here

After `Forget`, a subsequent `SendDatagram` is rejected for up to `DEAD_GC_TTL`, so an app-level remove → add of the same peer inside 60 s stalls. Pre-existing and separate from this issue.
