### PR TITLE
iroh-ble-transport: close the iroh connections riding a pipe we take away

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ crates/iroh-ble-transport/src/
     ├── registry.rs          # Pure state machine (PeerEntry/PeerPhase) + actor loop
     ├── peer.rs              # PeerEntry, PeerPhase, PeerCommand, PeerAction, ChannelHandle
     ├── routing.rs           # TransportRouting: Token ↔ peer-identity, KeyPrefix → DeviceId
+    ├── conns.rs             # Live iroh connections indexed by pipe; closed when their pipe dies
     ├── events.rs            # blew event pumps (run_central_events, run_peripheral_events)
     ├── pipe.rs              # Per-peer data pipe: ReliableChannel ↔ inbox/outbox channels
     ├── reliable.rs          # Selective-Repeat ARQ sliding-window protocol + fragment canary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "blew"
-version = "0.3.0"
+version = "0.4.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc26017c8941f033a5555555e12a69cfd7c6eb0353c5bc012eb3cabaa8e5490"
+checksum = "d38b8b4db9c6a804d3a83e806fb30dab64f61f5d1110748967e6daf1dcaacac1"
 dependencies = [
  "bitflags 2.13.1",
  "bluer",
@@ -518,6 +518,7 @@ dependencies = [
  "ndk-context",
  "objc2",
  "objc2-core-bluetooth",
+ "objc2-core-foundation",
  "objc2-foundation",
  "parking_lot",
  "serde_json",
@@ -6299,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-blew"
-version = "0.3.1"
+version = "0.4.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb38668d67fdcb3922eaa47210030be265f7c39ed47cd5f50f551423e04da8b3"
+checksum = "d92355c06894b718340114feee779ad7930183be984b6eea14e5291c6d283dbd"
 dependencies = [
  "blew",
  "jni 0.22.4",

--- a/crates/iroh-ble-transport/Cargo.toml
+++ b/crates/iroh-ble-transport/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 testing = []
 
 [dependencies]
-blew = "0.3"
+blew = "0.4.0-beta.2"
 uuid = { version = "1", features = ["v4"] }
 thiserror = "2"
 tracing = "0.1"
@@ -41,7 +41,7 @@ tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 rand = "0.10"
-blew = { version = "0.3", features = ["testing"] }
+blew = { version = "0.4.0-beta.2", features = ["testing"] }
 proptest = "1"
 
 [profile.test.package.proptest]

--- a/crates/iroh-ble-transport/src/lib.rs
+++ b/crates/iroh-ble-transport/src/lib.rs
@@ -12,6 +12,8 @@ pub use blew::{BleDevice, Central, CentralConfig, DeviceId, Peripheral};
 pub use error::{BleError, BleResult};
 pub use transport::hook::BleDedupHook;
 pub use transport::{
-    BlePeerInfo, BlePeerPhase, BleTransport, BleTransportBuilder, ConnectPath, InMemoryPeerStore,
-    IncomingPacket, KEY_PREFIX_LEN, KeyPrefix, L2capPolicy, PeerSnapshot, PeerStore,
+    BLE_CLOSE_CODE_CONFLICT, BLE_CLOSE_CODE_RETRY, BLE_CLOSE_REASON_CONFLICT,
+    BLE_CLOSE_REASON_EVICTED, BLE_CLOSE_REASON_PIPE_CLOSED, BlePeerInfo, BlePeerPhase,
+    BleTransport, BleTransportBuilder, ConnectPath, InMemoryPeerStore, IncomingPacket,
+    KEY_PREFIX_LEN, KeyPrefix, L2capPolicy, PeerSnapshot, PeerStore,
 };

--- a/crates/iroh-ble-transport/src/transport/conns.rs
+++ b/crates/iroh-ble-transport/src/transport/conns.rs
@@ -1,0 +1,395 @@
+//! Index of the live iroh connections riding each BLE pipe, and the
+//! close vocabulary the transport uses when it takes a pipe away.
+//!
+//! Two teardown directions exist and both need this table:
+//!
+//! - **iroh closes first** — the hook's per-connection `closed()` watcher
+//!   fires, and once the last connection on a pipe is gone the transport
+//!   drains the pipe. That is what the watch-id bookkeeping here is for.
+//! - **the pipe dies first** — dedup eviction, a dead link, an adapter
+//!   loss. iroh has no way to learn this on its own: `CustomEndpoint`
+//!   cannot report a path as dead, and iroh does not migrate an existing
+//!   `Connection` onto a freshly resolved `CustomAddr` (see
+//!   `EndpointResolveStream`). A connection whose only path was that pipe
+//!   can never carry traffic again, so we close it here rather than
+//!   leaving the application blocked on a read until its own deadline.
+//!
+//! Where the close shows up: the local application — the one whose pipe
+//! we took away — sees `ConnectionError::LocallyClosed`, which carries
+//! neither code nor reason; what it gains is that its read returns at
+//! once instead of hanging. The `(code, reason)` pair below is what the
+//! *peer* sees, as `ApplicationClosed`, and what our own logs record.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use iroh::endpoint::{VarInt, WeakConnectionHandle};
+use iroh_base::{EndpointId, TransportAddr};
+
+use crate::transport::routing::{StableConnId, parse_token_addr};
+use crate::transport::transport::BLE_TRANSPORT_ID;
+
+/// Close code for a conflict the peer should not redial: another
+/// connection to the same endpoint is already the live one.
+pub const BLE_CLOSE_CODE_CONFLICT: u32 = 0;
+
+/// Close code for a BLE-side teardown a redial can fix.
+pub const BLE_CLOSE_CODE_RETRY: u32 = 1;
+
+/// Sent to the peer whose handshake the dedup rule rejected.
+pub const BLE_CLOSE_REASON_CONFLICT: &[u8] = b"ble_conflict";
+
+/// Sent on connections whose pipe the dedup rule evicted. Another pipe
+/// to the same endpoint is already routable, so a redial succeeds
+/// immediately.
+pub const BLE_CLOSE_REASON_EVICTED: &[u8] = b"ble_evicted";
+
+/// Sent on connections whose pipe died for any other reason (dead link,
+/// drain, adapter loss). A redial succeeds once the peer is reachable
+/// again.
+pub const BLE_CLOSE_REASON_PIPE_CLOSED: &[u8] = b"ble_pipe_closed";
+
+/// A connection handle the registry can close. Implemented for
+/// [`WeakConnectionHandle`]; the trait exists so tests can drive the
+/// registry without a live iroh endpoint.
+pub trait ConnHandle: Send + Sync + 'static {
+    /// Close this connection if — and only if — every path still open on
+    /// it rides `pipe`. A connection that also holds a relay path, or a
+    /// second BLE path on another live pipe, has not lost its last path
+    /// and is left alone. Returns whether it was closed.
+    fn close_if_only_path(&self, pipe: StableConnId, code: VarInt, reason: &[u8]) -> bool;
+}
+
+impl ConnHandle for WeakConnectionHandle {
+    fn close_if_only_path(&self, pipe: StableConnId, code: VarInt, reason: &[u8]) -> bool {
+        // A weak handle that no longer upgrades belongs to a connection
+        // the application already dropped: nothing to close.
+        let Some(conn) = self.upgrade() else {
+            return false;
+        };
+        // `paths()` only ever lists open paths, so no closed-path filter here.
+        let has_other_path = conn.paths().iter().any(|path| match path.remote_addr() {
+            TransportAddr::Custom(addr) if addr.id() == BLE_TRANSPORT_ID => {
+                parse_token_addr(addr).ok() != Some(pipe.as_u64())
+            }
+            _ => true,
+        });
+        if has_other_path {
+            return false;
+        }
+        // Close before the temporary strong handle drops: if ours was the
+        // last one, dropping it first would close the connection with
+        // iroh's default reason instead of ours.
+        conn.close(code, reason);
+        true
+    }
+}
+
+type ActiveConnectionKey = (EndpointId, StableConnId);
+
+/// The connections in one (endpoint, pipe) bucket, by watch id.
+type WatchedConns = HashMap<u64, Arc<dyn ConnHandle>>;
+
+/// Live connections, bucketed by the peer they authenticated as and the
+/// pipe they route over.
+#[derive(Default)]
+pub struct ConnectionRegistry {
+    next_id: AtomicU64,
+    inner: parking_lot::Mutex<HashMap<ActiveConnectionKey, WatchedConns>>,
+}
+
+impl std::fmt::Debug for ConnectionRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionRegistry")
+            .field("buckets", &self.inner.lock().len())
+            .finish()
+    }
+}
+
+impl ConnectionRegistry {
+    /// Register a connection and return the watch id its `closed()`
+    /// watcher must hand back to [`Self::remove_and_is_empty`].
+    pub fn insert(
+        &self,
+        endpoint_id: EndpointId,
+        stable_id: StableConnId,
+        handle: Arc<dyn ConnHandle>,
+    ) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        self.inner
+            .lock()
+            .entry((endpoint_id, stable_id))
+            .or_default()
+            .insert(id, handle);
+        id
+    }
+
+    /// Drop one watch and report whether its (endpoint, pipe) bucket is
+    /// now empty — i.e. whether the last connection on that pipe is gone.
+    pub fn remove_and_is_empty(
+        &self,
+        endpoint_id: EndpointId,
+        stable_id: StableConnId,
+        watch_id: u64,
+    ) -> bool {
+        let mut inner = self.inner.lock();
+        let key = (endpoint_id, stable_id);
+        let Some(ids) = inner.get_mut(&key) else {
+            return true;
+        };
+        ids.remove(&watch_id);
+        if ids.is_empty() {
+            inner.remove(&key);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Close every connection whose last path rides `pipe`, and return
+    /// how many were closed. Buckets for all endpoints are considered:
+    /// the pipe is going away regardless of who authenticated over it.
+    ///
+    /// Entries are left in place — the `closed()` watcher the hook
+    /// installed is the sole owner of removal, and closing here is what
+    /// makes it fire.
+    pub fn close_pipe(&self, pipe: StableConnId, code: VarInt, reason: &[u8]) -> usize {
+        // Collect under the lock, close outside it: closing wakes the
+        // watcher tasks, which come straight back here to remove
+        // themselves.
+        let handles: Vec<Arc<dyn ConnHandle>> = {
+            let inner = self.inner.lock();
+            inner
+                .iter()
+                .filter(|((_, id), _)| *id == pipe)
+                .flat_map(|(_, watches)| watches.values().cloned())
+                .collect()
+        };
+        handles
+            .iter()
+            .filter(|handle| handle.close_if_only_path(pipe, code, reason))
+            .count()
+    }
+}
+
+/// Close every iroh connection riding a pipe the dedup rule just
+/// evicted. Their only path is about to disappear and iroh has no way
+/// to notice, so without this the application is left blocked on a read
+/// that never returns. The pipe that won the eviction is already
+/// routable by the time this runs, so a redial lands straight on it —
+/// hence [`BLE_CLOSE_CODE_RETRY`].
+///
+/// Returns the total number of connections closed.
+pub fn close_evicted_pipes(registry: &ConnectionRegistry, evicted: &[StableConnId]) -> usize {
+    let mut total = 0;
+    for pipe in evicted {
+        let closed = registry.close_pipe(
+            *pipe,
+            VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_EVICTED,
+        );
+        if closed > 0 {
+            tracing::info!(
+                evicted_pipe = %pipe,
+                closed,
+                "closed iroh connections on an evicted BLE pipe"
+            );
+        }
+        total += closed;
+    }
+    total
+}
+
+/// A [`ConnHandle`] that records close attempts instead of talking to
+/// iroh. Lets the pipe-teardown paths be exercised without a live
+/// endpoint.
+#[cfg(any(test, feature = "testing"))]
+#[derive(Debug, Default)]
+pub struct RecordingConn {
+    other_paths: bool,
+    closes: parking_lot::Mutex<Vec<(u64, Vec<u8>)>>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl RecordingConn {
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// A connection that still holds a path the dying pipe doesn't own,
+    /// and so must survive the close.
+    #[must_use]
+    pub fn with_other_paths() -> Arc<Self> {
+        Arc::new(Self {
+            other_paths: true,
+            closes: parking_lot::Mutex::new(Vec::new()),
+        })
+    }
+
+    /// The `(code, reason)` of every close this connection accepted.
+    #[must_use]
+    pub fn closes(&self) -> Vec<(u64, Vec<u8>)> {
+        self.closes.lock().clone()
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl ConnHandle for RecordingConn {
+    fn close_if_only_path(&self, _pipe: StableConnId, code: VarInt, reason: &[u8]) -> bool {
+        if self.other_paths {
+            return false;
+        }
+        self.closes
+            .lock()
+            .push((code.into_inner(), reason.to_vec()));
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use RecordingConn as FakeConn;
+
+    fn endpoint(seed: u8) -> EndpointId {
+        iroh_base::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    #[test]
+    fn close_pipe_closes_every_connection_on_that_pipe() {
+        let registry = ConnectionRegistry::default();
+        let pipe = StableConnId::for_test(1);
+        let first = FakeConn::new();
+        let second = FakeConn::new();
+        registry.insert(endpoint(1), pipe, Arc::clone(&first) as Arc<dyn ConnHandle>);
+        registry.insert(
+            endpoint(2),
+            pipe,
+            Arc::clone(&second) as Arc<dyn ConnHandle>,
+        );
+
+        let closed = registry.close_pipe(
+            pipe,
+            VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_EVICTED,
+        );
+
+        assert_eq!(closed, 2, "both connections on the evicted pipe are closed");
+        for conn in [&first, &second] {
+            assert_eq!(
+                conn.closes(),
+                vec![(
+                    u64::from(BLE_CLOSE_CODE_RETRY),
+                    BLE_CLOSE_REASON_EVICTED.to_vec()
+                )]
+            );
+        }
+    }
+
+    #[test]
+    fn close_pipe_leaves_connections_on_other_pipes_alone() {
+        let registry = ConnectionRegistry::default();
+        let dying = StableConnId::for_test(1);
+        let survivor = StableConnId::for_test(2);
+        let conn = FakeConn::new();
+        registry.insert(
+            endpoint(1),
+            survivor,
+            Arc::clone(&conn) as Arc<dyn ConnHandle>,
+        );
+
+        let closed = registry.close_pipe(
+            dying,
+            VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_EVICTED,
+        );
+
+        assert_eq!(closed, 0);
+        assert!(conn.closes().is_empty());
+    }
+
+    #[test]
+    fn close_pipe_spares_a_connection_that_still_has_another_path() {
+        let registry = ConnectionRegistry::default();
+        let pipe = StableConnId::for_test(1);
+        let multipath = FakeConn::with_other_paths();
+        let single = FakeConn::new();
+        registry.insert(
+            endpoint(1),
+            pipe,
+            Arc::clone(&multipath) as Arc<dyn ConnHandle>,
+        );
+        registry.insert(
+            endpoint(2),
+            pipe,
+            Arc::clone(&single) as Arc<dyn ConnHandle>,
+        );
+
+        let closed = registry.close_pipe(
+            pipe,
+            VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_PIPE_CLOSED,
+        );
+
+        assert_eq!(closed, 1, "only the single-path connection is closed");
+        assert!(multipath.closes().is_empty());
+        assert_eq!(
+            single.closes(),
+            vec![(
+                u64::from(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED.to_vec()
+            )]
+        );
+    }
+
+    #[test]
+    fn close_pipe_on_an_unknown_pipe_is_a_noop() {
+        let registry = ConnectionRegistry::default();
+        assert_eq!(
+            registry.close_pipe(
+                StableConnId::for_test(9),
+                VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn only_reports_empty_after_last_watch_is_removed() {
+        let registry = ConnectionRegistry::default();
+        let endpoint_id = endpoint(1);
+        let stable_id = StableConnId::for_test(7);
+
+        let first = registry.insert(endpoint_id, stable_id, FakeConn::new());
+        let second = registry.insert(endpoint_id, stable_id, FakeConn::new());
+
+        assert!(
+            !registry.remove_and_is_empty(endpoint_id, stable_id, first),
+            "first close must not report empty while another connection is active"
+        );
+        assert!(
+            registry.remove_and_is_empty(endpoint_id, stable_id, second),
+            "last close reports the peer/stable-id bucket empty"
+        );
+    }
+
+    #[test]
+    fn buckets_by_stable_id() {
+        let registry = ConnectionRegistry::default();
+        let endpoint_id = endpoint(2);
+        let old_id = StableConnId::for_test(8);
+        let new_id = StableConnId::for_test(9);
+
+        let old_watch = registry.insert(endpoint_id, old_id, FakeConn::new());
+        let _new_watch = registry.insert(endpoint_id, new_id, FakeConn::new());
+
+        assert!(
+            registry.remove_and_is_empty(endpoint_id, old_id, old_watch),
+            "old stable-id bucket is empty even if replacement stable-id has an active connection"
+        );
+    }
+}

--- a/crates/iroh-ble-transport/src/transport/conns.rs
+++ b/crates/iroh-ble-transport/src/transport/conns.rs
@@ -23,6 +23,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use iroh::endpoint::{VarInt, WeakConnectionHandle};
 use iroh_base::{EndpointId, TransportAddr};
@@ -86,23 +87,73 @@ impl ConnHandle for WeakConnectionHandle {
     }
 }
 
+/// How long a closed pipe is remembered, so a handshake that completes
+/// just after its pipe died still gets closed. Generous next to the
+/// window it covers (a `promote()` that raced the pipe worker's exit),
+/// and bounded below by [`MAX_CLOSED_PIPES`].
+const CLOSED_PIPE_TTL: Duration = Duration::from_secs(30);
+const MAX_CLOSED_PIPES: usize = 128;
+
 type ActiveConnectionKey = (EndpointId, StableConnId);
 
 /// The connections in one (endpoint, pipe) bucket, by watch id.
 type WatchedConns = HashMap<u64, Arc<dyn ConnHandle>>;
 
+/// Why and when a pipe was closed, kept so late registrations on it can
+/// be closed the same way.
+#[derive(Clone)]
+struct ClosedPipe {
+    code: VarInt,
+    reason: Vec<u8>,
+    closed_at: Instant,
+    /// Insertion order, so overflow always drops the oldest close and
+    /// never the one being recorded right now (`closed_at` ties when
+    /// several pipes die inside the same instant).
+    seq: u64,
+}
+
+#[derive(Default)]
+struct RegistryInner {
+    buckets: HashMap<ActiveConnectionKey, WatchedConns>,
+    closed: HashMap<StableConnId, ClosedPipe>,
+    next_close_seq: u64,
+}
+
+impl RegistryInner {
+    fn prune_closed(&mut self, now: Instant) {
+        self.closed
+            .retain(|_, closed| now.saturating_duration_since(closed.closed_at) <= CLOSED_PIPE_TTL);
+        if self.closed.len() <= MAX_CLOSED_PIPES {
+            return;
+        }
+        let mut by_age: Vec<(StableConnId, u64)> = self
+            .closed
+            .iter()
+            .map(|(id, closed)| (*id, closed.seq))
+            .collect();
+        by_age.sort_by_key(|(_, seq)| *seq);
+        let overflow = self.closed.len() - MAX_CLOSED_PIPES;
+        for (id, _) in by_age.into_iter().take(overflow) {
+            self.closed.remove(&id);
+        }
+    }
+}
+
 /// Live connections, bucketed by the peer they authenticated as and the
-/// pipe they route over.
+/// pipe they route over, plus a short memory of the pipes that have
+/// already been closed.
 #[derive(Default)]
 pub struct ConnectionRegistry {
     next_id: AtomicU64,
-    inner: parking_lot::Mutex<HashMap<ActiveConnectionKey, WatchedConns>>,
+    inner: parking_lot::Mutex<RegistryInner>,
 }
 
 impl std::fmt::Debug for ConnectionRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let inner = self.inner.lock();
         f.debug_struct("ConnectionRegistry")
-            .field("buckets", &self.inner.lock().len())
+            .field("buckets", &inner.buckets.len())
+            .field("closed_pipes", &inner.closed.len())
             .finish()
     }
 }
@@ -110,6 +161,14 @@ impl std::fmt::Debug for ConnectionRegistry {
 impl ConnectionRegistry {
     /// Register a connection and return the watch id its `closed()`
     /// watcher must hand back to [`Self::remove_and_is_empty`].
+    ///
+    /// A handshake can complete on a pipe that is already gone: the pipe
+    /// worker may exit between `promote()` accepting the connection and
+    /// this call, in which case [`Self::close_pipe`] has already run and
+    /// found an empty bucket. Registration and teardown therefore agree
+    /// under one lock — a connection arriving on a closed pipe is not
+    /// registered at all, and is closed on the spot with the reason that
+    /// pipe was closed for.
     pub fn insert(
         &self,
         endpoint_id: EndpointId,
@@ -117,11 +176,31 @@ impl ConnectionRegistry {
         handle: Arc<dyn ConnHandle>,
     ) -> u64 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
-        self.inner
-            .lock()
-            .entry((endpoint_id, stable_id))
-            .or_default()
-            .insert(id, handle);
+        let late = {
+            let mut inner = self.inner.lock();
+            inner.prune_closed(Instant::now());
+            match inner.closed.get(&stable_id).cloned() {
+                Some(closed) => Some(closed),
+                None => {
+                    inner
+                        .buckets
+                        .entry((endpoint_id, stable_id))
+                        .or_default()
+                        .insert(id, Arc::clone(&handle));
+                    None
+                }
+            }
+        };
+        // Close outside the lock, as `close_pipe` does.
+        if let Some(closed) = late
+            && handle.close_if_only_path(stable_id, closed.code, &closed.reason)
+        {
+            tracing::info!(
+                %endpoint_id,
+                pipe = %stable_id,
+                "closed an iroh connection that handshook on an already-dead BLE pipe"
+            );
+        }
         id
     }
 
@@ -135,12 +214,12 @@ impl ConnectionRegistry {
     ) -> bool {
         let mut inner = self.inner.lock();
         let key = (endpoint_id, stable_id);
-        let Some(ids) = inner.get_mut(&key) else {
+        let Some(ids) = inner.buckets.get_mut(&key) else {
             return true;
         };
         ids.remove(&watch_id);
         if ids.is_empty() {
-            inner.remove(&key);
+            inner.buckets.remove(&key);
             true
         } else {
             false
@@ -153,14 +232,31 @@ impl ConnectionRegistry {
     ///
     /// Entries are left in place — the `closed()` watcher the hook
     /// installed is the sole owner of removal, and closing here is what
-    /// makes it fire.
+    /// makes it fire. The pipe is also remembered as closed, so a
+    /// connection registered after this point (a handshake that raced
+    /// the pipe worker's exit) is closed by [`Self::insert`] rather than
+    /// stranded on a dead pipe.
     pub fn close_pipe(&self, pipe: StableConnId, code: VarInt, reason: &[u8]) -> usize {
         // Collect under the lock, close outside it: closing wakes the
         // watcher tasks, which come straight back here to remove
         // themselves.
         let handles: Vec<Arc<dyn ConnHandle>> = {
-            let inner = self.inner.lock();
+            let mut inner = self.inner.lock();
+            let now = Instant::now();
+            let seq = inner.next_close_seq;
+            inner.next_close_seq += 1;
+            inner.closed.insert(
+                pipe,
+                ClosedPipe {
+                    code,
+                    reason: reason.to_vec(),
+                    closed_at: now,
+                    seq,
+                },
+            );
+            inner.prune_closed(now);
             inner
+                .buckets
                 .iter()
                 .filter(|((_, id), _)| *id == pipe)
                 .flat_map(|(_, watches)| watches.values().cloned())
@@ -356,6 +452,73 @@ mod tests {
             ),
             0
         );
+    }
+
+    #[test]
+    fn a_connection_registered_after_its_pipe_closed_is_closed_at_once() {
+        // The pipe worker can exit between `promote()` accepting a
+        // handshake and the hook registering it, so `close_pipe` sees an
+        // empty bucket. Without the closed-pipe memory the connection
+        // would sit on a dead pipe with nothing left to close it — the
+        // original hanging read, one race narrower.
+        let registry = ConnectionRegistry::default();
+        let pipe = StableConnId::for_test(1);
+
+        assert_eq!(
+            registry.close_pipe(
+                pipe,
+                VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED
+            ),
+            0,
+            "nothing registered yet"
+        );
+
+        let late = FakeConn::new();
+        let watch = registry.insert(endpoint(1), pipe, Arc::clone(&late) as Arc<dyn ConnHandle>);
+
+        assert_eq!(
+            late.closes(),
+            vec![(
+                u64::from(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED.to_vec()
+            )],
+            "the late registration is closed with the reason its pipe died for"
+        );
+        assert!(
+            registry.remove_and_is_empty(endpoint(1), pipe, watch),
+            "it is never added to the bucket, so its watcher reports empty"
+        );
+    }
+
+    #[test]
+    fn closing_one_pipe_does_not_taint_registrations_on_another() {
+        let registry = ConnectionRegistry::default();
+        let dead = StableConnId::for_test(1);
+        let live = StableConnId::for_test(2);
+        registry.close_pipe(
+            dead,
+            VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_PIPE_CLOSED,
+        );
+
+        let conn = FakeConn::new();
+        registry.insert(endpoint(1), live, Arc::clone(&conn) as Arc<dyn ConnHandle>);
+
+        assert!(conn.closes().is_empty());
+    }
+
+    #[test]
+    fn closed_pipe_memory_stays_bounded() {
+        let registry = ConnectionRegistry::default();
+        for n in 0..(MAX_CLOSED_PIPES as u64 * 2) {
+            registry.close_pipe(
+                StableConnId::for_test(n),
+                VarInt::from_u32(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED,
+            );
+        }
+        assert!(registry.inner.lock().closed.len() <= MAX_CLOSED_PIPES);
     }
 
     #[test]

--- a/crates/iroh-ble-transport/src/transport/driver.rs
+++ b/crates/iroh-ble-transport/src/transport/driver.rs
@@ -129,6 +129,11 @@ pub struct Driver<I: BleInterface> {
     /// pipe open (or reuses a reservation's id) and evicts on pipe
     /// close. `poll_send` and `poll_recv` both resolve via this.
     routing: Arc<crate::transport::routing::Routing>,
+    /// Live iroh connections indexed by pipe. Closed when their pipe
+    /// dies — iroh cannot observe that on its own. Defaults to an empty
+    /// registry so tests that build a `Driver` directly need not supply
+    /// one; the real transport installs its own via `with_connections`.
+    connections: Arc<crate::transport::conns::ConnectionRegistry>,
 }
 
 impl<I: BleInterface> Driver<I> {
@@ -152,7 +157,19 @@ impl<I: BleInterface> Driver<I> {
             empty_frames_counter,
             store,
             routing,
+            connections: Arc::new(crate::transport::conns::ConnectionRegistry::default()),
         }
+    }
+
+    /// Install the transport's connection registry. Separate from `new`
+    /// so the many test call sites don't all have to pass one.
+    #[must_use]
+    pub fn with_connections(
+        mut self,
+        connections: Arc<crate::transport::conns::ConnectionRegistry>,
+    ) -> Self {
+        self.connections = connections;
+        self
     }
 
     pub async fn execute(&self, action: PeerAction) {
@@ -312,6 +329,7 @@ impl<I: BleInterface> Driver<I> {
                 // across the dial — only outbound pipes match
                 // reservations (inbound accepts have no resolver).
                 let routing = Arc::clone(&self.routing);
+                let connections = Arc::clone(&self.connections);
                 let direction = direction_for_role(role);
                 let (stable_id, reservation_endpoint) = match target_endpoint
                     .and_then(|endpoint| routing.consume_reservation_for_endpoint(&endpoint))
@@ -356,6 +374,27 @@ impl<I: BleInterface> Driver<I> {
                     // Drop the pool entry before the pipe itself so
                     // the pool never references a non-existent pipe.
                     routing.evict_pipe_state(stable_id);
+                    // The pipe is gone and iroh has no way to learn that:
+                    // a connection whose only path was this pipe would
+                    // otherwise sit there until the application's own
+                    // deadline. Close after `evict_pipe_state` so the
+                    // `ConnectionClosed` events these closes provoke find
+                    // no routable entry and don't loop back as a fresh
+                    // `Stalled` for a pipe that is already dead.
+                    let closed = connections.close_pipe(
+                        stable_id,
+                        iroh::endpoint::VarInt::from_u32(
+                            crate::transport::conns::BLE_CLOSE_CODE_RETRY,
+                        ),
+                        crate::transport::conns::BLE_CLOSE_REASON_PIPE_CLOSED,
+                    );
+                    if closed > 0 {
+                        tracing::info!(
+                            %stable_id,
+                            closed,
+                            "closed iroh connections riding a BLE pipe that went away"
+                        );
+                    }
                     routing.evict_pipe(stable_id);
                 });
                 let ready = PeerCommand::DataPipeReady {
@@ -877,6 +916,88 @@ mod tests {
             }
             other => panic!("expected DataPipeReady, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn pipe_exit_closes_the_iroh_connections_riding_that_pipe() {
+        // A pipe going away is invisible to iroh: it cannot report a
+        // path as dead, and it never migrates an existing Connection
+        // onto a newly resolved CustomAddr. Left alone, a connection
+        // whose only path was this pipe sits there until the
+        // application's own deadline fires.
+        use crate::transport::conns::{
+            BLE_CLOSE_CODE_RETRY, BLE_CLOSE_REASON_PIPE_CLOSED, ConnHandle, ConnectionRegistry,
+            RecordingConn,
+        };
+        use crate::transport::peer::{ConnectPath, ConnectRole};
+
+        let iface = Arc::new(MockBleInterface::new());
+        let (tx, mut rx) = mpsc::channel(16);
+        let (incoming_tx, _incoming_rx) = mpsc::channel::<IncomingPacket>(4);
+        let routing = Arc::new(crate::transport::routing::Routing::new());
+        let connections = Arc::new(ConnectionRegistry::default());
+        let driver = Driver::new(
+            iface,
+            tx,
+            incoming_tx,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(crate::transport::store::InMemoryPeerStore::new()),
+            Arc::clone(&routing),
+        )
+        .with_connections(Arc::clone(&connections));
+
+        driver
+            .execute(PeerAction::StartDataPipe {
+                device_id: blew::DeviceId::from("dying-pipe"),
+                tx_gen: 1,
+                role: ConnectRole::Central,
+                target_endpoint: None,
+                path: ConnectPath::Gatt,
+                l2cap_channel: None,
+            })
+            .await;
+
+        let ready = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let pipes = routing.pipes_for_debug();
+        assert_eq!(pipes.len(), 1);
+        let stable_id = pipes[0].id;
+
+        let endpoint = iroh_base::SecretKey::from_bytes(&[0x59u8; 32]).public();
+        let conn = RecordingConn::new();
+        connections.insert(
+            endpoint,
+            stable_id,
+            Arc::clone(&conn) as Arc<dyn ConnHandle>,
+        );
+
+        // Dropping DataPipeReady drops the outbound sender, which is how
+        // the registry signals a pipe is done: the supervisor exits.
+        drop(ready);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while conn.closes().is_empty() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("pipe exit must close the connections riding it");
+
+        assert_eq!(
+            conn.closes(),
+            vec![(
+                u64::from(BLE_CLOSE_CODE_RETRY),
+                BLE_CLOSE_REASON_PIPE_CLOSED.to_vec()
+            )]
+        );
+        assert!(
+            routing.pipes_for_debug().is_empty(),
+            "the pipe is evicted from routing as before"
+        );
     }
 
     #[tokio::test]

--- a/crates/iroh-ble-transport/src/transport/events.rs
+++ b/crates/iroh-ble-transport/src/transport/events.rs
@@ -92,7 +92,7 @@ pub async fn run_central_events(
                 }
                 PeerCommand::Advertised {
                     prefix,
-                    device,
+                    device_id: device.id,
                     rssi,
                 }
             }

--- a/crates/iroh-ble-transport/src/transport/hook.rs
+++ b/crates/iroh-ble-transport/src/transport/hook.rs
@@ -1,12 +1,14 @@
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use blew::DeviceId;
 use iroh::endpoint::{AfterHandshakeOutcome, Connection, EndpointHooks, VarInt};
 use iroh_base::{EndpointId, TransportAddr};
 use tokio::sync::mpsc;
 
+use crate::transport::conns::{
+    BLE_CLOSE_CODE_CONFLICT, BLE_CLOSE_REASON_CONFLICT, ConnHandle, ConnectionRegistry,
+    close_evicted_pipes,
+};
 use crate::transport::routing::parse_token_addr;
 use crate::transport::routing::{PromoteOutcome, Routing, StableConnId};
 use crate::transport::transport::BLE_TRANSPORT_ID;
@@ -64,7 +66,7 @@ pub struct BleDedupHook {
     self_endpoint: EndpointId,
     routing: Arc<Routing>,
     tx: mpsc::UnboundedSender<HookEvent>,
-    active_connections: Arc<ActiveConnections>,
+    connections: Arc<ConnectionRegistry>,
 }
 
 impl BleDedupHook {
@@ -73,52 +75,13 @@ impl BleDedupHook {
         self_endpoint: EndpointId,
         routing: Arc<Routing>,
         tx: mpsc::UnboundedSender<HookEvent>,
+        connections: Arc<ConnectionRegistry>,
     ) -> Self {
         Self {
             self_endpoint,
             routing,
             tx,
-            active_connections: Arc::new(ActiveConnections::default()),
-        }
-    }
-}
-
-type ActiveConnectionKey = (EndpointId, StableConnId);
-
-#[derive(Debug, Default)]
-struct ActiveConnections {
-    next_id: AtomicU64,
-    inner: parking_lot::Mutex<HashMap<ActiveConnectionKey, HashSet<u64>>>,
-}
-
-impl ActiveConnections {
-    fn insert(&self, endpoint_id: EndpointId, stable_id: StableConnId) -> u64 {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
-        self.inner
-            .lock()
-            .entry((endpoint_id, stable_id))
-            .or_default()
-            .insert(id);
-        id
-    }
-
-    fn remove_and_is_empty(
-        &self,
-        endpoint_id: EndpointId,
-        stable_id: StableConnId,
-        watch_id: u64,
-    ) -> bool {
-        let mut inner = self.inner.lock();
-        let key = (endpoint_id, stable_id);
-        let Some(ids) = inner.get_mut(&key) else {
-            return true;
-        };
-        ids.remove(&watch_id);
-        if ids.is_empty() {
-            inner.remove(&key);
-            true
-        } else {
-            false
+            connections,
         }
     }
 }
@@ -164,8 +127,8 @@ impl EndpointHooks for BleDedupHook {
                         evicted_devices: Vec::new(),
                     });
                     return AfterHandshakeOutcome::Reject {
-                        error_code: VarInt::from_u32(0),
-                        reason: b"ble_conflict".to_vec(),
+                        error_code: VarInt::from_u32(BLE_CLOSE_CODE_CONFLICT),
+                        reason: BLE_CLOSE_REASON_CONFLICT.to_vec(),
                     };
                 }
                 PromoteOutcome::Accepted { evicted } => {
@@ -186,7 +149,16 @@ impl EndpointHooks for BleDedupHook {
                         evicted_devices = evicted_devices.len(),
                         "BleDedupHook: promoted to routable"
                     );
-                    let watch_id = self.active_connections.insert(remote_endpoint, stable_id);
+                    // Close the connections riding the evicted pipes
+                    // before the BLE teardown the forwarder kicks off
+                    // below: the pipe under them is about to disappear,
+                    // and iroh has no way to observe that.
+                    close_evicted_pipes(&self.connections, &evicted);
+                    let watch_id = self.connections.insert(
+                        remote_endpoint,
+                        stable_id,
+                        Arc::new(conn.weak_handle()) as Arc<dyn ConnHandle>,
+                    );
                     close_watch = Some((stable_id, watch_id));
                 }
             }
@@ -205,10 +177,10 @@ impl EndpointHooks for BleDedupHook {
             // keeps it alive and disables close-on-drop for its real owner.
             let closed = conn.weak_handle().closed();
             let tx = self.tx.clone();
-            let active_connections = Arc::clone(&self.active_connections);
+            let connections = Arc::clone(&self.connections);
             tokio::spawn(async move {
                 let _ = closed.await;
-                if active_connections.remove_and_is_empty(remote_endpoint, stable_id, watch_id) {
+                if connections.remove_and_is_empty(remote_endpoint, stable_id, watch_id) {
                     let _ = tx.send(HookEvent::ConnectionClosed {
                         endpoint_id: remote_endpoint,
                         stable_id,
@@ -217,49 +189,5 @@ impl EndpointHooks for BleDedupHook {
             });
         }
         AfterHandshakeOutcome::Accept
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn endpoint(seed: u8) -> EndpointId {
-        iroh_base::SecretKey::from_bytes(&[seed; 32]).public()
-    }
-
-    #[test]
-    fn active_connections_only_reports_empty_after_last_watch_is_removed() {
-        let active = ActiveConnections::default();
-        let endpoint_id = endpoint(1);
-        let stable_id = StableConnId::for_test(7);
-
-        let first = active.insert(endpoint_id, stable_id);
-        let second = active.insert(endpoint_id, stable_id);
-
-        assert!(
-            !active.remove_and_is_empty(endpoint_id, stable_id, first),
-            "first close must not report empty while another connection is active"
-        );
-        assert!(
-            active.remove_and_is_empty(endpoint_id, stable_id, second),
-            "last close reports the peer/stable-id bucket empty"
-        );
-    }
-
-    #[test]
-    fn active_connections_buckets_by_stable_id() {
-        let active = ActiveConnections::default();
-        let endpoint_id = endpoint(2);
-        let old_id = StableConnId::for_test(8);
-        let new_id = StableConnId::for_test(9);
-
-        let old_watch = active.insert(endpoint_id, old_id);
-        let _new_watch = active.insert(endpoint_id, new_id);
-
-        assert!(
-            active.remove_and_is_empty(endpoint_id, old_id, old_watch),
-            "old stable-id bucket is empty even if replacement stable-id has an active connection"
-        );
     }
 }

--- a/crates/iroh-ble-transport/src/transport/mod.rs
+++ b/crates/iroh-ble-transport/src/transport/mod.rs
@@ -1,5 +1,6 @@
 //! Transport layer module tree. `BleTransport` itself lives in `transport.rs`.
 
+pub mod conns;
 pub mod dedup;
 pub mod driver;
 pub mod events;
@@ -20,6 +21,10 @@ pub mod watchdog;
 #[cfg(feature = "testing")]
 pub mod test_util;
 
+pub use conns::{
+    BLE_CLOSE_CODE_CONFLICT, BLE_CLOSE_CODE_RETRY, BLE_CLOSE_REASON_CONFLICT,
+    BLE_CLOSE_REASON_EVICTED, BLE_CLOSE_REASON_PIPE_CLOSED,
+};
 pub use driver::IncomingPacket;
 pub use peer::{ConnectPath, KEY_PREFIX_LEN, KeyPrefix};
 pub use store::{InMemoryPeerStore, PeerSnapshot, PeerStore};

--- a/crates/iroh-ble-transport/src/transport/peer.rs
+++ b/crates/iroh-ble-transport/src/transport/peer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::Waker;
 use std::time::Instant;
 
-use blew::{BleDevice, DeviceId, DisconnectCause, L2capChannel};
+use blew::{DeviceId, DisconnectCause, L2capChannel};
 use bytes::Bytes;
 
 pub const KEY_PREFIX_LEN: usize = 12;
@@ -270,7 +270,7 @@ pub struct ChannelHandle {
 pub enum PeerCommand {
     Advertised {
         prefix: KeyPrefix,
-        device: BleDevice,
+        device_id: DeviceId,
         rssi: Option<i16>,
     },
     CentralConnected {

--- a/crates/iroh-ble-transport/src/transport/registry.rs
+++ b/crates/iroh-ble-transport/src/transport/registry.rs
@@ -86,9 +86,9 @@ impl Registry {
         match cmd {
             PeerCommand::Advertised {
                 prefix,
-                device,
+                device_id,
                 rssi,
-            } => self.handle_advertised(&mut actions, now, prefix, device, rssi),
+            } => self.handle_advertised(&mut actions, now, prefix, device_id, rssi),
             PeerCommand::SendDatagram {
                 device_id,
                 target_endpoint,
@@ -417,11 +417,10 @@ impl Registry {
         actions: &mut Vec<PeerAction>,
         now: std::time::Instant,
         prefix: crate::transport::peer::KeyPrefix,
-        device: blew::BleDevice,
+        device_id: blew::DeviceId,
         rssi: Option<i16>,
     ) {
         let _ = rssi;
-        let device_id = device.id.clone();
 
         let mut has_verified_live = false;
         let mut verified_before = false;
@@ -2150,12 +2149,7 @@ mod tests {
                         let endpoint = iroh_base::SecretKey::from_bytes(&[endpoint_seed; 32]).public();
                         reg.handle(PeerCommand::Advertised {
                             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-                            device: blew::BleDevice {
-                                id: device_id.clone(),
-                                name: None,
-                                rssi: None,
-                                services: vec![],
-                            },
+                            device_id: device_id.clone(),
                             rssi: None,
                         })
                     }
@@ -2309,12 +2303,7 @@ mod tests {
                         let endpoint = endpoint_from_seed(endpoint_seed);
                         reg.handle(PeerCommand::Advertised {
                             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-                            device: blew::BleDevice {
-                                id: device_id,
-                                name: None,
-                                rssi: None,
-                                services: vec![],
-                            },
+                            device_id,
                             rssi: None,
                         })
                     }
@@ -2459,38 +2448,28 @@ mod tests {
     #[test]
     fn advertised_new_peer_creates_discovered_entry() {
         let mut reg = Registry::new_for_test();
-        let device = blew::BleDevice {
-            id: blew::DeviceId::from("dev-1"),
-            name: None,
-            rssi: Some(-60),
-            services: vec![],
-        };
+        let device_id = blew::DeviceId::from("dev-1");
         let actions = reg.handle(PeerCommand::Advertised {
             prefix: [1u8; 12],
-            device: device.clone(),
+            device_id: device_id.clone(),
             rssi: Some(-60),
         });
         assert!(actions.is_empty(), "no actions for first advertisement");
-        let entry = reg.peer(&device.id).unwrap();
+        let entry = reg.peer(&device_id).unwrap();
         assert!(matches!(entry.phase, PeerPhase::Discovered { .. }));
-        assert_eq!(entry.device_id, device.id);
+        assert_eq!(entry.device_id, device_id);
     }
 
     #[test]
     fn advertised_duplicate_in_connecting_is_noop() {
         let mut reg = Registry::new_for_test();
-        let device = blew::BleDevice {
-            id: blew::DeviceId::from("dev-2"),
-            name: None,
-            rssi: None,
-            services: vec![],
-        };
+        let device_id = blew::DeviceId::from("dev-2");
         reg.handle(PeerCommand::Advertised {
             prefix: [2u8; 12],
-            device: device.clone(),
+            device_id: device_id.clone(),
             rssi: None,
         });
-        if let Some(entry) = reg.peers.get_mut(&device.id) {
+        if let Some(entry) = reg.peers.get_mut(&device_id) {
             entry.phase = PeerPhase::Connecting {
                 attempt: 0,
                 started: std::time::Instant::now(),
@@ -2499,12 +2478,12 @@ mod tests {
         }
         let actions = reg.handle(PeerCommand::Advertised {
             prefix: [2u8; 12],
-            device: device.clone(),
+            device_id: device_id.clone(),
             rssi: None,
         });
         assert!(actions.is_empty());
         assert!(matches!(
-            reg.peer(&device.id).unwrap().phase,
+            reg.peer(&device_id).unwrap().phase,
             PeerPhase::Connecting { .. }
         ));
     }
@@ -3075,12 +3054,7 @@ mod tests {
         let device_id = blew::DeviceId::from("dev-3");
         reg.handle(PeerCommand::Advertised {
             prefix: [3u8; 12],
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
         let actions = reg.handle(PeerCommand::SendDatagram {
@@ -3108,12 +3082,7 @@ mod tests {
         let endpoint = iroh_base::SecretKey::from_bytes(&[0x5Au8; 32]).public();
         reg.handle(PeerCommand::Advertised {
             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
 
@@ -3153,12 +3122,7 @@ mod tests {
         let endpoint = iroh_base::SecretKey::from_bytes(&[0x61u8; 32]).public();
         reg.handle(PeerCommand::Advertised {
             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
 
@@ -3219,12 +3183,7 @@ mod tests {
         let endpoint = iroh_base::SecretKey::from_bytes(&[0x62u8; 32]).public();
         reg.handle(PeerCommand::Advertised {
             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
 
@@ -3276,12 +3235,7 @@ mod tests {
         let endpoint = iroh_base::SecretKey::from_bytes(&[0x63u8; 32]).public();
         reg.handle(PeerCommand::Advertised {
             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
 
@@ -3335,12 +3289,7 @@ mod tests {
         let endpoint = iroh_base::SecretKey::from_bytes(&[0x64u8; 32]).public();
         reg.handle(PeerCommand::Advertised {
             prefix: crate::transport::routing::prefix_from_endpoint(&endpoint),
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
         let _ = reg.handle(PeerCommand::SendDatagram {
@@ -3586,12 +3535,7 @@ mod tests {
     fn advertise(reg: &mut Registry, device_id: &DeviceId, prefix: [u8; 12]) -> Vec<PeerAction> {
         reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         })
     }
@@ -4187,12 +4131,7 @@ mod tests {
         let device_id = blew::DeviceId::from("dev-30");
         reg.handle(PeerCommand::Advertised {
             prefix: [30u8; 12],
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         });
         assert_eq!(
@@ -6015,19 +5954,14 @@ mod tests {
     #[test]
     fn advertised_records_prefix_on_peer_entry() {
         let mut reg = Registry::new_for_test();
-        let device = blew::BleDevice {
-            id: blew::DeviceId::from("dev-prefix"),
-            name: None,
-            rssi: None,
-            services: vec![],
-        };
+        let device_id = blew::DeviceId::from("dev-prefix");
         let prefix: crate::transport::peer::KeyPrefix = [0xAB; 12];
         reg.handle(PeerCommand::Advertised {
             prefix,
-            device: device.clone(),
+            device_id: device_id.clone(),
             rssi: None,
         });
-        assert_eq!(reg.peer(&device.id).unwrap().prefix, Some(prefix));
+        assert_eq!(reg.peer(&device_id).unwrap().prefix, Some(prefix));
     }
 
     #[test]
@@ -6276,12 +6210,7 @@ mod tests {
 
         let actions = reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: new_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: new_dev.clone(),
             rssi: None,
         });
 
@@ -6330,12 +6259,7 @@ mod tests {
         assert!(before_phase_disc);
         let _ = reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: alive_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: alive_dev.clone(),
             rssi: None,
         });
         let after = &reg.peers[&alive_dev];
@@ -6366,12 +6290,7 @@ mod tests {
 
         let _ = reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: dev_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: dev_id.clone(),
             rssi: None,
         });
 
@@ -6392,12 +6311,7 @@ mod tests {
 
         let _ = reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: dev_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: dev_id.clone(),
             rssi: None,
         });
 
@@ -6443,12 +6357,7 @@ mod tests {
 
         let actions = reg.handle(PeerCommand::Advertised {
             prefix: peer_prefix,
-            device: blew::BleDevice {
-                id: peer_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: peer_dev.clone(),
             rssi: None,
         });
 
@@ -6499,12 +6408,7 @@ mod tests {
 
         let actions = reg.handle(PeerCommand::Advertised {
             prefix: peer_prefix,
-            device: blew::BleDevice {
-                id: peer_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: peer_dev.clone(),
             rssi: None,
         });
 
@@ -6556,12 +6460,7 @@ mod tests {
 
         let _ = reg.handle(PeerCommand::Advertised {
             prefix: peer_prefix,
-            device: blew::BleDevice {
-                id: peer_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: peer_dev.clone(),
             rssi: None,
         });
         let deadline = match reg.peers[&peer_dev].phase {
@@ -6612,12 +6511,7 @@ mod tests {
             });
         let _ = reg.handle(PeerCommand::Advertised {
             prefix: peer_prefix,
-            device: blew::BleDevice {
-                id: pending_dev.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: pending_dev.clone(),
             rssi: None,
         });
         assert!(matches!(

--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -1869,12 +1869,7 @@ mod tests {
         let mut reg = Registry::new_for_test();
         reg.handle(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: old_device.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: old_device.clone(),
             rssi: None,
         });
 

--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -539,7 +539,8 @@ impl BleTransport {
             Arc::clone(&empty_frames),
             Arc::clone(&store),
             Arc::clone(&routing),
-        );
+        )
+        .with_connections(Arc::clone(&connections));
 
         if l2cap_policy == L2capPolicy::PreferL2cap {
             match construct_step("l2cap_listener", async {

--- a/crates/iroh-ble-transport/src/transport/transport.rs
+++ b/crates/iroh-ble-transport/src/transport/transport.rs
@@ -267,6 +267,10 @@ pub struct BleTransport {
     /// and the per-endpoint waker set. Exposed via
     /// `routing_snapshot()` for telemetry.
     routing: Arc<crate::transport::routing::Routing>,
+    /// Live iroh connections, indexed by the BLE pipe they route over.
+    /// The hook populates it; the hook (on dedup eviction) and the
+    /// driver (on pipe death) close through it.
+    connections: Arc<crate::transport::conns::ConnectionRegistry>,
     tx_bytes: Arc<AtomicU64>,
     rx_bytes: Arc<AtomicU64>,
     retransmits: Arc<AtomicU64>,
@@ -525,6 +529,7 @@ impl BleTransport {
             inbox_tx.clone(),
         ));
         let routing = Arc::new(crate::transport::routing::Routing::new());
+        let connections = Arc::new(crate::transport::conns::ConnectionRegistry::default());
         let driver = Driver::new(
             iface,
             inbox_tx.clone(),
@@ -614,6 +619,7 @@ impl BleTransport {
             },
             incoming_rx: tokio::sync::Mutex::new(Some(incoming_rx)),
             routing,
+            connections,
             tx_bytes,
             rx_bytes,
             retransmits,
@@ -644,6 +650,7 @@ impl BleTransport {
             self.local_id,
             Arc::clone(&self.routing),
             self.hook_tx.clone(),
+            Arc::clone(&self.connections),
         )
     }
 

--- a/crates/iroh-ble-transport/tests/integration_dedup.rs
+++ b/crates/iroh-ble-transport/tests/integration_dedup.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::task::Waker;
 
 use arc_swap::ArcSwap;
-use blew::{BleDevice, DeviceId};
+use blew::DeviceId;
 use bytes::Bytes;
 use parking_lot::Mutex;
 
@@ -31,15 +31,6 @@ fn zero_counters() -> (Arc<AtomicU64>, Arc<AtomicU64>, Arc<AtomicU64>) {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
     )
-}
-
-fn ble_device(id: &DeviceId) -> BleDevice {
-    BleDevice {
-        id: id.clone(),
-        name: None,
-        rssi: None,
-        services: vec![],
-    }
 }
 
 fn waker_from_channel(tx: mpsc::Sender<()>) -> std::task::Waker {
@@ -217,7 +208,7 @@ async fn symmetric_dial_resolves_to_one_pipe_per_side() {
     a.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_b,
-            device: ble_device(&dev_b),
+            device_id: dev_b.clone(),
             rssi: None,
         })
         .await
@@ -241,7 +232,7 @@ async fn symmetric_dial_resolves_to_one_pipe_per_side() {
     b.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_a,
-            device: ble_device(&dev_a),
+            device_id: dev_a.clone(),
             rssi: None,
         })
         .await
@@ -384,7 +375,7 @@ async fn advertising_flood_does_not_redial_after_verified() {
     a.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_b,
-            device: ble_device(&dev_b),
+            device_id: dev_b.clone(),
             rssi: None,
         })
         .await
@@ -457,7 +448,7 @@ async fn advertising_flood_does_not_redial_after_verified() {
         a.inbox_tx
             .send(PeerCommand::Advertised {
                 prefix: prefix_b,
-                device: ble_device(&dev_b),
+                device_id: dev_b.clone(),
                 rssi: None,
             })
             .await
@@ -543,7 +534,7 @@ async fn l2cap_handover_timeout_reverts_to_gatt() {
     node.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_peer,
-            device: ble_device(&dev_peer),
+            device_id: dev_peer.clone(),
             rssi: None,
         })
         .await

--- a/crates/iroh-ble-transport/tests/integration_dedup.rs
+++ b/crates/iroh-ble-transport/tests/integration_dedup.rs
@@ -685,3 +685,64 @@ async fn l2cap_handover_timeout_reverts_to_gatt() {
         "l2cap_upgrade_failed must be true after handover timeout"
     );
 }
+
+/// Issue #17: when the promotion rule evicts a pipe, the iroh
+/// connections riding it must be closed. Their only path is about to
+/// disappear and iroh cannot observe that — a `CustomEndpoint` has no
+/// way to report a path as dead — so an application blocked on a read
+/// would otherwise hang until its own deadline fired.
+#[test]
+fn evicting_a_pipe_closes_the_iroh_connections_riding_it() {
+    use iroh_ble_transport::transport::conns::{
+        BLE_CLOSE_CODE_RETRY, BLE_CLOSE_REASON_EVICTED, ConnHandle, ConnectionRegistry,
+        RecordingConn, close_evicted_pipes,
+    };
+    use iroh_ble_transport::transport::routing::{Direction, PromoteOutcome, Routing};
+
+    let routing = Routing::new();
+    let connections = ConnectionRegistry::default();
+    let me = endpoint_with_byte(0xFF);
+    let peer = endpoint_with_byte(0x01);
+
+    // The peer's first MAC: we dialed it, it handshook, it is routable.
+    let first = routing.register_pipe(DeviceId::from("73:EA:12:0E:B6:16"), Direction::Outbound);
+    routing.register_pending(first, Some(peer));
+    assert!(matches!(
+        routing.promote(first, &me, peer),
+        PromoteOutcome::Accepted { .. }
+    ));
+
+    // An application connection is live on that pipe...
+    let stale = RecordingConn::new();
+    connections.insert(peer, first, Arc::clone(&stale) as Arc<dyn ConnHandle>);
+
+    // ...when the same peer, having rotated its MAC, handshakes again.
+    let second = routing.register_pipe(DeviceId::from("49:73:AA:8F:3A:78"), Direction::Outbound);
+    routing.register_pending(second, Some(peer));
+    let PromoteOutcome::Accepted { evicted } = routing.promote(second, &me, peer) else {
+        panic!("a fresh handshake from the same peer must win");
+    };
+    assert_eq!(evicted, vec![first], "the old pipe is the one evicted");
+
+    let survivor = RecordingConn::new();
+    connections.insert(peer, second, Arc::clone(&survivor) as Arc<dyn ConnHandle>);
+
+    assert_eq!(close_evicted_pipes(&connections, &evicted), 1);
+    assert_eq!(
+        stale.closes(),
+        vec![(
+            u64::from(BLE_CLOSE_CODE_RETRY),
+            BLE_CLOSE_REASON_EVICTED.to_vec()
+        )],
+        "the connection on the evicted pipe is closed as retryable"
+    );
+    assert!(
+        survivor.closes().is_empty(),
+        "the connection on the winning pipe is untouched"
+    );
+    assert_eq!(
+        routing.routable_pipe_for(&peer),
+        Some(second),
+        "the surviving pipe is already routable, so a redial lands on it"
+    );
+}

--- a/crates/iroh-ble-transport/tests/mesh_integration.rs
+++ b/crates/iroh-ble-transport/tests/mesh_integration.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::AtomicU64;
 use std::task::Waker;
 
 use arc_swap::ArcSwap;
-use blew::{BleDevice, DeviceId};
+use blew::DeviceId;
 use bytes::Bytes;
 use parking_lot::Mutex;
 
@@ -34,15 +34,6 @@ fn zero_counters() -> (Arc<AtomicU64>, Arc<AtomicU64>, Arc<AtomicU64>) {
 
 fn prefix_for(byte: u8) -> KeyPrefix {
     [byte; KEY_PREFIX_LEN]
-}
-
-fn ble_device(id: &DeviceId) -> BleDevice {
-    BleDevice {
-        id: id.clone(),
-        name: None,
-        rssi: None,
-        services: vec![],
-    }
 }
 
 fn waker_from_channel(tx: mpsc::Sender<()>) -> std::task::Waker {
@@ -108,7 +99,7 @@ async fn triangle_send_fans_out_to_both_peers() {
     a.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_for(0xB1),
-            device: ble_device(&b.device_id),
+            device_id: b.device_id.clone(),
             rssi: None,
         })
         .await
@@ -116,7 +107,7 @@ async fn triangle_send_fans_out_to_both_peers() {
     a.inbox_tx
         .send(PeerCommand::Advertised {
             prefix: prefix_for(0xC1),
-            device: ble_device(&c.device_id),
+            device_id: c.device_id.clone(),
             rssi: None,
         })
         .await
@@ -182,7 +173,7 @@ async fn symmetric_connect_converges_to_one_channel() {
             a.inbox_tx
                 .send(PeerCommand::Advertised {
                     prefix: prefix_for(0xB1),
-                    device: ble_device(&b.device_id),
+                    device_id: b.device_id.clone(),
                     rssi: None,
                 })
                 .await
@@ -202,7 +193,7 @@ async fn symmetric_connect_converges_to_one_channel() {
             b.inbox_tx
                 .send(PeerCommand::Advertised {
                     prefix: prefix_for(0xA1),
-                    device: ble_device(&a.device_id),
+                    device_id: a.device_id.clone(),
                     rssi: None,
                 })
                 .await
@@ -272,7 +263,7 @@ async fn one_peer_flapping_does_not_disturb_others() {
         a.inbox_tx
             .send(PeerCommand::Advertised {
                 prefix: prefix_for(prefix_byte),
-                device: ble_device(peer),
+                device_id: peer.clone(),
                 rssi: None,
             })
             .await
@@ -386,7 +377,7 @@ async fn adapter_off_on_one_node_does_not_evict_others() {
         from_inbox
             .send(PeerCommand::Advertised {
                 prefix: prefix_for(prefix_byte),
-                device: ble_device(peer),
+                device_id: peer.clone(),
                 rssi: None,
             })
             .await

--- a/crates/iroh-ble-transport/tests/mock_integration.rs
+++ b/crates/iroh-ble-transport/tests/mock_integration.rs
@@ -94,12 +94,7 @@ async fn mid_session_disconnect_drains_and_closes_channel() {
     let prefix: KeyPrefix = [2u8; KEY_PREFIX_LEN];
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await
@@ -206,12 +201,7 @@ async fn local_teardown_lets_the_peer_be_redialed_immediately() {
     let prefix: KeyPrefix = [7u8; KEY_PREFIX_LEN];
     let advertise = || PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     };
     let (waker_tx, _waker_rx) = mpsc::channel::<()>(4);
@@ -325,12 +315,7 @@ async fn adapter_toggle_reconnects_all_peers_with_single_purge() {
         let device_id = blew::DeviceId::from(format!("dev-{i}").as_str());
         tx.send(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: device_id.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: device_id.clone(),
             rssi: None,
         })
         .await
@@ -472,12 +457,7 @@ async fn version_mismatch_deads_peer_and_closes_channel() {
     let prefix: KeyPrefix = [0x77; KEY_PREFIX_LEN];
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await
@@ -570,12 +550,7 @@ async fn version_match_lets_data_pipe_start() {
     let prefix: KeyPrefix = [0x78; KEY_PREFIX_LEN];
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await
@@ -671,12 +646,7 @@ async fn mock_fabric_handles_bidirectional_traffic() {
     central_inbox_tx
         .send(PeerCommand::Advertised {
             prefix,
-            device: blew::BleDevice {
-                id: fabric.peripheral_as_device.clone(),
-                name: None,
-                rssi: None,
-                services: vec![],
-            },
+            device_id: fabric.peripheral_as_device.clone(),
             rssi: None,
         })
         .await
@@ -814,12 +784,7 @@ async fn forget_then_gc_then_rediscover_creates_fresh_peer() {
     let prefix: KeyPrefix = [7u8; KEY_PREFIX_LEN];
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await
@@ -865,12 +830,7 @@ async fn forget_then_gc_then_rediscover_creates_fresh_peer() {
     // get blocked by any stale state.
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await
@@ -939,12 +899,7 @@ async fn connect_failure_retries_on_next_tick() {
     let prefix: KeyPrefix = [9u8; KEY_PREFIX_LEN];
     tx.send(PeerCommand::Advertised {
         prefix,
-        device: blew::BleDevice {
-            id: device_id.clone(),
-            name: None,
-            rssi: None,
-            services: vec![],
-        },
+        device_id: device_id.clone(),
         rssi: None,
     })
     .await

--- a/demos/iroh-ble-chat/src-tauri/Cargo.toml
+++ b/demos/iroh-ble-chat/src-tauri/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "0.23"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-deep-link = "2"
-tauri-plugin-blew = "0.3.1"
+tauri-plugin-blew = "0.4.0-beta.2"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-barcode-scanner = "2"


### PR DESCRIPTION
Fixes #17.

## The defect

Two teardown directions exist and only one was wired up. When *iroh*
closes first, the hook's `closed()` watcher drains the pipe (#13). When
the *pipe* dies first — a dedup eviction, in the reported case — nothing
propagates back up: the connections riding it are neither closed nor
errored, so an application blocked on a read hangs until its own deadline
(a flat 30 s in the libquiet capture).

There is no cheaper signal available. `CustomEndpoint` (iroh 1.1) has no
way to report a path as dead, and per the note on `EndpointResolveStream`
iroh never migrates an existing `Connection` onto a freshly resolved
`CustomAddr`. Once the pipe is gone, a connection whose only path was
that pipe is dead — closing it is what turns the hang into an immediate
redial.

## The fix

New `transport::conns` module: an index of live iroh connections by the
pipe they route over. It absorbs the hook's `ActiveConnections` watch-id
bookkeeping (which already had the right key, but threw away the handle)
and adds `close_pipe`.

Two call sites, one per commit:

1. **Dedup eviction** (`hook.rs`, in the `PromoteOutcome::Accepted` arm)
   closes with `ble_evicted`, ahead of the BLE teardown the forwarder
   starts. The winning pipe is already routable by then, so a redial
   lands straight on it with no backoff.
2. **Any other pipe death** (`driver.rs`, at the pipe worker's exit)
   closes with `ble_pipe_closed`. Covers dead links, wedged-pipe drains,
   `Forgotten`, and adapter loss — same defect, same choke point.

**Multipath guard**: a connection is closed only if *every* path still
open on it rides the dying pipe. One that also holds a relay path, or a
second BLE path on another live pipe, has not lost its last path and is
left alone.

**Ordering**: the driver-side close runs after `evict_pipe_state`, so the
`ConnectionClosed` events it provokes find no routable entry and cannot
loop back as a fresh `Stalled` for a pipe that is already dead.

## Close vocabulary

| code | reason | meaning |
|------|--------|---------|
| 0 | `ble_conflict` | `AfterHandshakeOutcome::Reject` — another connection to this endpoint is already the live one (unchanged behaviour, now via constants) |
| 1 | `ble_evicted` | dedup took this pipe; another path is already routable — redial now |
| 1 | `ble_pipe_closed` | the pipe under this connection died — redial when the peer is reachable |

All five constants are re-exported from the crate root.

One thing worth knowing for the consumer side: `ConnectionError::LocallyClosed`
is a unit variant, so the application whose pipe we took away sees only
"locally closed" — the code/reason pair reaches the *peer* (as
`ApplicationClosed`) and our logs. What the local app gains is that its
read returns at once instead of hanging. If distinguishing *why* locally
turns out to matter, the natural follow-up is an explicit signal on
`BleTransport` rather than an error-code lookup; happy to add it if
libquiet wants it.

## Tests

- `conns.rs`: close-all-on-pipe, spare other pipes, spare a connection
  with another open path, unknown-pipe no-op, plus the two moved
  watch-id tests.
- `driver.rs`: a real pipe worker is started, a connection registered on
  its `StableConnId`, and the pipe dropped — asserts the connection is
  closed with `ble_pipe_closed` and the pipe still leaves routing.
- `tests/integration_dedup.rs`: the issue's exact shape — one peer, two
  MACs, both outbound — drives `Routing::promote` and asserts the loser's
  connection is closed as retryable while the winner's is untouched and
  already routable.

`mise run verify` green: fmt, clippy pedantic, 354 tests.

## Not covered

- A connection that acquired its BLE path *after* `after_handshake` (a
  QUIC migration onto a BLE address) is not in the registry. iroh 1.1
  gives no hook for that; the multipath guard means we under-close rather
  than over-close.
- The two `disconnect callback did not fire; force-closing GATT` warnings
  in the capture are a blew-side issue — worth a separate issue on
  `mcginty/blew`.
